### PR TITLE
added image and link generation for showcaseitems

### DIFF
--- a/app/api/chains/controller.py
+++ b/app/api/chains/controller.py
@@ -8,7 +8,7 @@ from .schema import (ChainGraphSchema, ChainResponseSchema,
                      ChainValidationResponseSchema, ChainImageSchema)
 from .service import chain_by_uid, create_chain, validate_chain
 
-from app.api.showcase.service import generate_image, get_image_url
+from app.api.showcase.service import get_image_url
 
 api = Namespace("Chains", description="Operations with chains")
 
@@ -69,12 +69,11 @@ class ChainsIdImage(Resource):
     """Chains"""
 
     @responds(schema=ChainImageSchema, many=False)
-    def get(self, uid) -> ChainGraph:
+    def get(self, uid) -> ChainImage:
         """Get image of chain with specific UID"""
 
         chain = chain_by_uid(uid)
-        filename = uid + '.png'
-        generate_image(filename, chain)
-        image_url = get_image_url(filename)
+        filename = f'{uid}.png'
+        image_url = get_image_url(filename, chain)
 
         return ChainImage(uid, image_url)

--- a/app/api/chains/controller.py
+++ b/app/api/chains/controller.py
@@ -3,10 +3,12 @@ from flask_accepts import accepts, responds
 from flask_restx import Namespace, Resource
 
 from .chain_convert_utils import chain_to_graph, graph_to_chain
-from .models import ChainGraph, ChainResponse, ChainValidationResponse
+from .models import ChainGraph, ChainResponse, ChainValidationResponse, ChainImage
 from .schema import (ChainGraphSchema, ChainResponseSchema,
-                     ChainValidationResponseSchema)
+                     ChainValidationResponseSchema, ChainImageSchema)
 from .service import chain_by_uid, create_chain, validate_chain
+
+from app.api.showcase.service import generate_image, get_image_url
 
 api = Namespace("Chains", description="Operations with chains")
 
@@ -60,3 +62,19 @@ class ChainsAddResource(Resource):
             return ChainResponse(uid, is_exists)
         else:
             return ChainResponse(None, False)
+
+
+@api.route("/image/<string:uid>")
+class ChainsIdImage(Resource):
+    """Chains"""
+
+    @responds(schema=ChainImageSchema, many=False)
+    def get(self, uid) -> ChainGraph:
+        """Get image of chain with specific UID"""
+
+        chain = chain_by_uid(uid)
+        filename = uid + '.png'
+        generate_image(filename, chain)
+        image_url = get_image_url(filename)
+
+        return ChainImage(uid, image_url)

--- a/app/api/chains/models.py
+++ b/app/api/chains/models.py
@@ -19,3 +19,9 @@ class ChainValidationResponse:
 class ChainResponse:
     uid: Optional[str]
     is_new: bool
+
+
+@dataclass
+class ChainImage:
+    uid: str
+    image_url: str

--- a/app/api/chains/schema.py
+++ b/app/api/chains/schema.py
@@ -24,6 +24,7 @@ class ChainResponseSchema(Schema):
     uid = fields.String(attribute='uid')
     is_new = fields.Bool(attribute='is_new')
 
+
 class ChainImageSchema(Schema):
     """Chain schema"""
 

--- a/app/api/chains/schema.py
+++ b/app/api/chains/schema.py
@@ -23,3 +23,9 @@ class ChainResponseSchema(Schema):
 
     uid = fields.String(attribute='uid')
     is_new = fields.Bool(attribute='is_new')
+
+class ChainImageSchema(Schema):
+    """Chain schema"""
+
+    uid = fields.String(attribute='uid')
+    image_url = fields.String(attribute='image_url')

--- a/app/api/showcase/service.py
+++ b/app/api/showcase/service.py
@@ -35,10 +35,10 @@ def all_showcase_items_ids() -> List[str]:
 
 
 def generate_image(filename, chain):
-    image_path = f'app/web/static/generated_images/{filename}'
+    image_path = f'{project_root()}/app/web/static/generated_images/{filename}'
     image = Path(image_path)
     if not image.exists():
-        dir = Path('app/web/static/generated_images/')
+        dir = Path(f'{project_root()}/app/web/static/generated_images/')
         if not dir.exists():
             dir.mkdir()
         chain.show(image_path)

--- a/app/api/showcase/service.py
+++ b/app/api/showcase/service.py
@@ -1,15 +1,32 @@
 from typing import List
 
+from pathlib import Path
+
 from utils import project_root
 from .models import Metadata, ShowcaseItem
 
+from fedot.core.chains.chain import Chain
+
+from flask import url_for
 
 def showcase_item_by_uid(case_id: str) -> ShowcaseItem:
     metadata = Metadata(metric_name='roc_auc', task_name='classification', dataset_name='scoring')
+
+    image_path = f"app/web/static/generated_images/{case_id}.png"
+    image = Path(image_path)
+    if not image.exists():
+        dir = Path("app/web/static/generated_images/")
+        if not dir.exists():
+            dir.mkdir()
+
+        saved_chain = Chain()
+        saved_chain.load("data/mocked_jsons/chain.json")
+        saved_chain.show(image_path)
+
     item = ShowcaseItem(case_id=case_id,
                         chain_id='ad39eb8c-6050-4734-9e0a-b9884a125a11',
                         description=f'This is a test description of the showcase item {case_id}',
-                        icon_path=f'{project_root()}/data/mocked_images/showcase.png',
+                        icon_path=url_for("static", filename=f"generated_images/{case_id}.png", _external=True),
                         metadata=metadata)
     return item
 

--- a/app/api/showcase/service.py
+++ b/app/api/showcase/service.py
@@ -13,13 +13,12 @@ from flask import url_for
 def showcase_item_by_uid(case_id: str) -> ShowcaseItem:
     metadata = Metadata(metric_name='roc_auc', task_name='classification', dataset_name='scoring')
 
-    filename = case_id + '.png'
+    filename = f'{case_id}.png'
 
     saved_chain = Chain()
     saved_chain.load('data/mocked_jsons/chain.json')
 
-    generate_image(filename, chain=saved_chain)
-    image_url = get_image_url(filename)
+    image_url = get_image_url(filename, chain=saved_chain)
 
     item = ShowcaseItem(case_id=case_id,
                         chain_id='ad39eb8c-6050-4734-9e0a-b9884a125a11',
@@ -34,7 +33,7 @@ def all_showcase_items_ids() -> List[str]:
     return items
 
 
-def generate_image(filename, chain):
+def get_image_url(filename, chain):
     image_path = f'{project_root()}/app/web/static/generated_images/{filename}'
     image = Path(image_path)
     if not image.exists():
@@ -42,7 +41,4 @@ def generate_image(filename, chain):
         if not dir.exists():
             dir.mkdir()
         chain.show(image_path)
-
-
-def get_image_url(filename):
     return url_for('static', filename=f'generated_images/{filename}', _external=True)

--- a/app/api/showcase/service.py
+++ b/app/api/showcase/service.py
@@ -9,24 +9,22 @@ from fedot.core.chains.chain import Chain
 
 from flask import url_for
 
+
 def showcase_item_by_uid(case_id: str) -> ShowcaseItem:
     metadata = Metadata(metric_name='roc_auc', task_name='classification', dataset_name='scoring')
 
-    image_path = f"app/web/static/generated_images/{case_id}.png"
-    image = Path(image_path)
-    if not image.exists():
-        dir = Path("app/web/static/generated_images/")
-        if not dir.exists():
-            dir.mkdir()
+    filename = case_id + '.png'
 
-        saved_chain = Chain()
-        saved_chain.load("data/mocked_jsons/chain.json")
-        saved_chain.show(image_path)
+    saved_chain = Chain()
+    saved_chain.load('data/mocked_jsons/chain.json')
+
+    generate_image(filename, chain=saved_chain)
+    image_url = get_image_url(filename)
 
     item = ShowcaseItem(case_id=case_id,
                         chain_id='ad39eb8c-6050-4734-9e0a-b9884a125a11',
                         description=f'This is a test description of the showcase item {case_id}',
-                        icon_path=url_for("static", filename=f"generated_images/{case_id}.png", _external=True),
+                        icon_path=image_url,
                         metadata=metadata)
     return item
 
@@ -34,3 +32,17 @@ def showcase_item_by_uid(case_id: str) -> ShowcaseItem:
 def all_showcase_items_ids() -> List[str]:
     items = ['item1', 'item2', 'item3', 'item4', 'item5']
     return items
+
+
+def generate_image(filename, chain):
+    image_path = f'app/web/static/generated_images/{filename}'
+    image = Path(image_path)
+    if not image.exists():
+        dir = Path('app/web/static/generated_images/')
+        if not dir.exists():
+            dir.mkdir()
+        chain.show(image_path)
+
+
+def get_image_url(filename):
+    return url_for('static', filename=f'generated_images/{filename}', _external=True)

--- a/test/test_chains.py
+++ b/test/test_chains.py
@@ -2,7 +2,7 @@ import json
 
 from fedot.core.chains.chain import Chain
 
-from app.api.showcase.service import generate_image, get_image_url
+from app.api.showcase.service import get_image_url
 from utils import project_root
 
 from pathlib import Path
@@ -49,11 +49,12 @@ def test_add_chain_endpoint(client):
     assert response['uid'] == existing_uid
 
 
-def test_chain_image_generating():
+def test_chain_image_endpoint(client):
     uid = 'test_chain'
-
+    response = client.get(f'api/chains/image/{uid}').json
     test_chain = Chain()
     test_chain.load(f'{project_root()}/data/mocked_jsons/chain.json')
-    filename = uid + '.png'
-    generate_image(filename, test_chain)
+    filename = f'{uid}.png'
+    image_url = get_image_url(filename, test_chain)
     assert Path(f'{project_root()}/app/web/static/generated_images/{filename}').exists()
+    assert image_url == response['image_url']

--- a/test/test_chains.py
+++ b/test/test_chains.py
@@ -1,6 +1,11 @@
 import json
 
+from fedot.core.chains.chain import Chain
+
+from app.api.showcase.service import generate_image, get_image_url
 from utils import project_root
+
+from pathlib import Path
 
 
 def test_get_chain_endpoint(client):
@@ -42,3 +47,13 @@ def test_add_chain_endpoint(client):
     response = client.post(f'api/chains/add', json=graph).json
     assert response['is_new'] is False
     assert response['uid'] == existing_uid
+
+
+def test_chain_image_generating():
+    uid = 'test_chain'
+
+    test_chain = Chain()
+    test_chain.load(f'{project_root()}/data/mocked_jsons/chain.json')
+    filename = uid + '.png'
+    generate_image(filename, test_chain)
+    assert Path(f'{project_root()}/app/web/static/generated_images/{filename}').exists()

--- a/test/test_chains.py
+++ b/test/test_chains.py
@@ -58,3 +58,4 @@ def test_chain_image_endpoint(client):
     image_url = get_image_url(filename, test_chain)
     assert Path(f'{project_root()}/app/web/static/generated_images/{filename}').exists()
     assert image_url == response['image_url']
+    

--- a/test/test_chains.py
+++ b/test/test_chains.py
@@ -58,4 +58,3 @@ def test_chain_image_endpoint(client):
     image_url = get_image_url(filename, test_chain)
     assert Path(f'{project_root()}/app/web/static/generated_images/{filename}').exists()
     assert image_url == response['image_url']
-    


### PR DESCRIPTION
The request returns a link to the generated image in static folder. For example, I took "chain.json" file from "data/mocked_jsons".
<img width="550" alt="Снимок экрана 2021-05-23 в 18 41 09" src="https://user-images.githubusercontent.com/16399597/119267276-7a1cf880-bbf6-11eb-8378-b1441a618eba.png">
