### PR TITLE
Fixes of new dependencies versions

### DIFF
--- a/app/singletons/db_service.py
+++ b/app/singletons/db_service.py
@@ -62,7 +62,7 @@ class DBServiceSingleton:
     def try_reinsert_one(self, collection: str, old_obj_query: Dict[str, Any], obj_to_add: Dict[str, Any]) -> None:
         if self.exists():
             try:
-                self._db[collection].remove(old_obj_query)
+                self._db[collection].delete_many(old_obj_query)
                 self._db[collection].insert_one(obj_to_add)
             except pymongo.errors.DuplicateKeyError:
                 print(f'{obj_to_add} already exists')

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ dnspython==2.1.0
 python-dotenv==0.19.0
 pandas>=1.1.0,<1.3.0; python_version <= '3.8'
 pandas>=1.3.0; python_version >='3.9'
+itsdangerous==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 https://github.com/nccr-itmo/FEDOT/archive/master.zip
-scikit_learn>=0.2.4; python_version <= '3.6'
 scikit_learn>=1.0.0; python_version >= '3.7'
 flask-socketio==5.0.1
 Flask==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 https://github.com/nccr-itmo/FEDOT/archive/master.zip
-scikit_learn==1.0.0
+scikit_learn>=0.2.4; python_version <= '3.6'
+scikit_learn>=1.0.0; python_version >= '3.7'
 flask-socketio==5.0.1
 Flask==1.1.1
 flask-accepts==0.10.0


### PR DESCRIPTION
Three site-packages received updates that broke local development.
1. One of the issues had to be fixed via requirements, as the exception appeared in a site-package that used an older version of this dependency.
2. The other one was caused by using a deprecated method in pymongo.
3. scikit-learn==1.0.0 used a deprecated attribute `use_label_encoder` of `XGBClassifier`