### PR TITLE
Frontend parameters hotfix

### DIFF
--- a/frontend/src/API/analytics/analyticsAPI.ts
+++ b/frontend/src/API/analytics/analyticsAPI.ts
@@ -25,10 +25,10 @@ export const analyticsAPI = {
       return Promise.reject(error);
     }
   },
-  async getResults(caseId: string, pipelineId: string) {
+  async getResults(caseId: string, individualId: string) {
     try {
       const res = await instance.get<IResult>(
-        `/analytics/results/${caseId}/${pipelineId}`
+        `/analytics/results/${caseId}/${individualId}`
       );
       return res.data;
     } catch (error: any) {

--- a/frontend/src/redux/sandbox/sandbox-actions.ts
+++ b/frontend/src/redux/sandbox/sandbox-actions.ts
@@ -136,11 +136,11 @@ export const getModelNames =
   };
 
 export const getResult =
-  (caseId: string, pipelineId: string): ThunkTypeAsync =>
+  (caseId: string, individualId: string): ThunkTypeAsync =>
   async (dispatch) => {
     dispatch(actionsSandbox.setResultLoading(true));
     try {
-      const result = await analyticsAPI.getResults(caseId, pipelineId);
+      const result = await analyticsAPI.getResults(caseId, individualId);
       dispatch(actionsSandbox.setResult(result));
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
Frontend used deprecated parameter name `pipelineId`. All occurrences were renamed to `IndividualId`.