### PR TITLE
FEDOT.Web 2.0: modernized GUI with live evolution monitoring and framework control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,11 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# FEDOT.Web 2.0
+node_modules/
+ui/dist/
+ui/tsconfig.tsbuildinfo
+.ruff_cache/
+.claude/
+backend/examples/example_scoring.csv

--- a/Dockerfile.v2
+++ b/Dockerfile.v2
@@ -1,0 +1,44 @@
+# Build the frontend, then serve it from the API container.
+FROM node:22-slim AS ui
+
+WORKDIR /ui
+COPY ui/package*.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY ui/ ./
+RUN npm run build
+
+
+FROM python:3.10-slim
+
+# FEDOT pulls in scientific wheels that need a toolchain for the few sdists.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY backend/pyproject.toml backend/pyproject.toml
+COPY backend/fedotweb backend/fedotweb
+
+# The published 0.7.5 wheel pins an incompatible GOLEM and kills a run on the
+# first badly-scoring pipeline; master has the fix.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install "fedot @ git+https://github.com/aimclub/FEDOT.git@master" \
+    && pip install ./backend
+
+COPY --from=ui /ui/dist /app/ui/dist
+
+ENV FEDOTWEB_HOST=0.0.0.0 \
+    FEDOTWEB_PORT=8000 \
+    FEDOTWEB_WORKSPACE=/data \
+    FEDOTWEB_STATIC_DIR=/app/ui/dist \
+    PYTHONUNBUFFERED=1
+
+VOLUME ["/data"]
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s \
+    CMD python -c "import urllib.request;urllib.request.urlopen('http://127.0.0.1:8000/api/health')"
+
+CMD ["python", "-m", "fedotweb"]

--- a/README.v2.md
+++ b/README.v2.md
@@ -1,0 +1,365 @@
+# FEDOT.Web 2.0
+
+Web interface for the [FEDOT](https://github.com/aimclub/FEDOT) AutoML framework and the
+[GOLEM](https://github.com/aimclub/GOLEM) graph optimiser.
+
+Version 2 is a new backend and frontend living alongside the original code
+(`app/` and `frontend/`, which are untouched). It targets **FEDOT master (0.7.5) /
+GOLEM 0.4.2**, starts without any external database, and can drive the framework rather
+than only display pre-baked results.
+
+```
+backend/    FastAPI service (fedotweb package)
+ui/         Vite + React 19 + TypeScript frontend
+app/        legacy Flask backend  (unchanged)
+frontend/   legacy CRA frontend   (unchanged)
+```
+
+## Quick start
+
+```bash
+python -m venv .venv && .venv/Scripts/activate
+pip install git+https://github.com/aimclub/FEDOT.git@master
+pip install -e backend[dev]
+cd ui && npm install && npm run build && cd ..
+python -m fedotweb
+```
+
+FEDOT comes from master rather than PyPI — see [below](#why-fedot-is-installed-from-master).
+
+Then open <http://127.0.0.1:8000>. The API reference is at `/docs`.
+
+For frontend development, run the API and the Vite dev server side by side —
+requests to `/api` are proxied, so the WebSocket works without extra configuration:
+
+```bash
+python -m fedotweb
+```
+
+```bash
+cd ui && npm run dev
+```
+
+## What it does
+
+### Pipeline structure and hyperparameters
+
+The pipeline canvas is [React Flow](https://reactflow.dev) with a dagre layout, zoom, pan
+and a minimap. Each node is a card showing the operation, its category, and the
+hyperparameters that differ from FEDOT's defaults — so a composed pipeline is readable
+without opening every node.
+
+The hyperparameter editor is generated from what FEDOT itself publishes:
+
+| Source | What it gives the UI |
+| --- | --- |
+| `PipelineSearchSpace` | parameter type (`continuous` / `discrete` / `categorical` / nested), sampling scope, hyperopt distribution |
+| `default_operation_params.json` | the default value applied to a new node |
+| `model_repository.json`, `data_operation_repository.json` | tags, supported tasks, input/output data types |
+
+So a continuous parameter gets a slider bounded by the same range the tuner searches
+(logarithmic when the distribution is `loguniform`), a discrete one gets an integer
+control, and a categorical one gets a dropdown of the actual admissible values. Values
+that differ from the default are marked, and can be reset individually.
+
+Nested search spaces — `glm`, where `family` and `link` are chosen together — are decoded
+into variant selectors rather than shown as opaque text.
+
+### The evolution history as a graph — live
+
+A fitness curve shows *that* the population improved. The history graph shows *how*: it
+is the genealogy of the run, and it is drawn **while the run is still going**, not only
+after it finishes.
+
+That distinction is what makes it a monitoring view. The saved `OptHistory` only exists
+once FEDOT returns, so a graph that waited for it would show nothing until the end.
+Instead the worker sends a `population` event from GOLEM's iteration callback each
+generation — every individual's uid, fitness, operations, pipeline structure and the
+operators that produced it — and the backend assembles the genealogy from those. When
+the run finishes, the same endpoint switches to the saved history; the response says
+which source it used (`source: "live" | "history"`).
+
+Both paths feed the same builder (`fedotweb/history/model.py`), so the graph you watch
+during a run and the one you read afterwards are the same drawing rather than two
+implementations that drift. While live, there is no final choice yet, so the leader is
+marked as *best so far* and the ancestry shown is the ancestry of whatever is winning at
+that moment — it re-roots as the leader changes.
+
+The graph is layered — generation `g` occupies layer `2g`, and the mutations and
+crossovers that produced generation `g` sit on layer `2g-1` — so it reads top to bottom
+with each generation on its own labelled row. Individuals are pipelines, coloured by how
+their fitness compares to the rest of the run; operators are the junctions where one
+pipeline became another. A pipeline that survives selection unchanged is joined to its
+copy in the next generation with a dashed edge, so a surviving line reads as an unbroken
+vertical run.
+
+By default only the ancestry of the final choice is drawn, because that is the story:
+which crossings and mutations actually led to the returned model. A toggle switches to
+the whole population — for a run of 14 generations at population 20 that is roughly 440
+nodes, which the canvas handles, but the lineage is what carries the meaning.
+
+Clicking any individual loads the pipeline it stands for and shows it in the same editor
+canvas, with the same typed hyperparameter inspector — so you can see exactly which
+values evolution settled on at that point, and copy the pipeline into the editor.
+
+Because the layers are known in advance, the layout is computed directly rather than
+handed to a general graph layout: rows are placed by layer, and only the order *within*
+each row is solved, using the barycentre heuristic to cut edge crossings. That keeps
+generations exactly aligned, which is the point of reading the graph vertically.
+
+Two details the graph is careful about, because both are easy to get subtly wrong:
+
+* GOLEM stores the seed populations (`initial_assumptions`, `extended_initial_assumptions`)
+  and the result (`final_choices`) as generations of their own. A run that reports ten
+  stored generations may have evolved only seven times. Those rows are labelled and
+  styled differently, and the generation count reflects evolution only.
+* An individual can leave a population and return — elitism reintroduces archived
+  graphs — so a parent is not always recorded in the generation immediately before its
+  child. Ancestry is resolved against the most recent earlier generation rather than
+  only the previous one; otherwise the returning pipeline appears with no incoming edge,
+  as if it came from nowhere. Generations that contributed nothing to the shown graph get
+  a labelled empty row so the numbering stays continuous.
+* GOLEM exposes two generation counters that are offset by one: the optimiser's
+  `current_generation_num` starts at one, while `native_generation` on an individual
+  starts at zero. Deciding which generation "owns" an individual by comparing those two
+  silently drops every operator, leaving a genealogy of nothing but survival edges. The
+  builder instead treats the generation where an individual *first appears* as the one
+  that draws its operators, which needs no counter at all and is correct for both
+  sources.
+
+`GET /api/runs/{uid}/lineage` returns the graph; `GET /api/runs/{uid}/lineage/{individual}`
+returns one individual's pipeline.
+
+### Where the score came from
+
+A run reports one number per metric. The **Objective** window on the results panel
+shows how that number was arrived at: the metric on every cross-validation fold, their
+mean — which *is* the fitness evolution compared pipelines by — the spread across folds,
+and the same pipeline scored once on the holdout.
+
+FEDOT averages the per-fold metrics and keeps only the average; the folds behind it are
+discarded, so they are recomputed on the same split `DataSourceSplitter` gives the
+composer. That the mean equals the arithmetic mean of the folds shown is asserted in the
+tests, because it is the whole claim the window makes.
+
+Values are shown as they read normally. FEDOT stores metrics it maximises negated, so
+ROC AUC lives internally as `-0.97`; both forms are in the payload, and which is which
+is derived from the metric itself — `from_maximised_metric` wraps with `functools.wraps`,
+so the wrapper carries `__wrapped__` and metrics that are already minimised do not.
+
+### What the pipeline rests on
+
+The **Sensitivity** window runs GOLEM's own structural analysis: each node is deleted,
+replaced and has its subtree removed; each edge is deleted and replaced. Every variant is
+refitted and rescored, and the result is a score ratio that GOLEM sign-normalises
+(`_compare_with_origin_by_metric` flips numerator and denominator by the metric's sign),
+so it reads the same for maximised and minimised metrics: **above 1 the change improved
+the objective** — that part is dead weight or replaceable — and below 1 the pipeline
+relies on it. That is also how GOLEM's own `optimize()` consumes these numbers: it
+applies a change when the ratio exceeds 1. The backend ships the verdict per entity
+(`improves`), so clients never re-derive the convention.
+
+Two things were needed to drive it. GOLEM's node and edge analyses fan out over a
+`multiprocessing.Pool` even for a single job, so the objective is pickled and shipped to
+each worker — that rules out a closure, and rules out defining it in the module run with
+`-m`, whose classes pickle against `__main__`; hence `analysis/scoring.py`. And the
+analysis works in GOLEM's graph space, not on a FEDOT pipeline, so the graph is adapted
+with `PipelineAdapter` going in and restored coming back. (The example in the FEDOT repo
+still calls the old signature and carries a `TODO` saying it needs fixing.)
+
+Both analyses refit pipelines many times, so they run out of process and are polled for;
+the most recent finished result for a run is reused rather than recomputed on reopening.
+
+### What happens to the data before the pipeline
+
+A pipeline graph is only half the story: FEDOT rewrites the input first. The
+**Preprocessing** panel on a dataset runs the framework's own preprocessor and reports,
+per column, the types actually found in the file, how many gaps there were, and the type
+the pipeline finally receives — plus the decisions behind any change.
+
+On the sample data this immediately shows something the graph never would: `x3`, a column
+of integers 0–3, arrives at the pipeline as `str`, because FEDOT reads a numeric column
+with fewer than 13 distinct values as categorical. Columns dropped as almost entirely
+empty (over 90% gaps), columns dropped for irreconcilable types, failed numeric
+conversions and the chosen encoders are all listed the same way.
+
+Index bookkeeping is the subtle part: the gap filter drops columns first, and the type
+corrector then works on the filtered matrix, so every index it reports is a position in
+that matrix, not in the file. The report maps everything back to file columns — otherwise
+one dropped column would silently shift the labels of every column after it.
+
+### Watching a run you started yourself
+
+The GUI does not have to be the thing that launches FEDOT. Add one import to your own
+script and the browser opens on the run as it starts:
+
+```python
+import fedotweb.autowatch          # noqa: F401
+
+from fedot import Fedot
+Fedot(problem='classification', timeout=10).fit(features='data.csv', target='target')
+```
+
+The import wraps `Fedot.fit`: the server comes up in a background thread if nothing is
+already serving, the run is registered, a tab opens on its page, and every generation is
+reported there — same fitness curve, same live genealogy, same controls. An already
+running server is reused, so several scripts can report into one GUI. If you passed your
+own `optimizer=`, this stays out of the way.
+
+For more control, or to name the run:
+
+```python
+from fedot import Fedot
+from fedotweb import watch
+
+with watch('sea level forecast') as session:
+    model = Fedot(problem='ts_forecasting', timeout=10, optimizer=session.optimizer)
+    model.fit(train)
+    model.predict(test)
+    session.record_result(model)      # optional: stores the pipeline and its metrics
+```
+
+`record_result` only reports metrics when the model has actually predicted something.
+Calling `get_metrics()` after a bare `fit` returns a number that looks like a score and
+means nothing, and a misleading metric is worse than a missing one.
+
+On a headless machine set `FEDOTWEB_AUTOWATCH_BROWSER=0`, or pass
+`open_browser=False`; the run is still recorded and the URL still printed.
+See `backend/examples/watch_a_script.py`.
+
+### Steering the evolution while it runs
+
+A live run has a control panel: population size, generation limit, time budget, and the
+mutation and crossover probabilities. Changes are picked up between generations, so a
+generation already in flight is never disturbed — which is why a change appears in "in
+force" one generation after you make it. Clearing a field hands that parameter back to
+GOLEM's own adaptive policy.
+
+There is also **Finish now**, which is not the same as **Stop**. Stop kills the worker
+and throws away whatever it had. Finish now lowers the generation limit so the optimiser
+returns through its normal path: FEDOT still fits the best pipeline it found and the run
+ends with a result and metrics. In practice it takes effect within seconds.
+
+Getting this to work needed care, because GOLEM re-derives some of these values itself.
+`_update_requirements` runs at the start of every generation and overwrites `pop_size`
+and both operator probabilities from adaptive sources, so assigning to those fields from
+outside would last exactly until the next generation began. The controls therefore work
+at the source: those two are supplied by objects implementing GOLEM's `AdaptiveParameter`
+protocol, and `fedotweb/runs/control.py` wraps them so an override survives the update —
+while still advancing the wrapped policy underneath, so releasing an override resumes the
+adaptive schedule rather than freezing it. The generation limit and the time budget are
+read live by the stopping conditions and can simply be assigned.
+
+The GUI and the worker are separate processes, so requests travel through a small JSON
+file in the run directory. `PATCH /api/runs/{uid}/controls` writes it; `GET` returns both
+what was asked for and what the optimiser is actually using.
+
+### Controlling the framework
+
+* Upload a CSV, inspect inferred column types, choose a target.
+* Configure a run: task, preset, metric, time budget, population size, generations,
+  depth, arity, CV folds, early stopping, parallelism, seed, tuning on/off.
+* Optionally start evolution from a pipeline you drew, instead of FEDOT's default
+  assumption.
+* Watch generations arrive live over a WebSocket: best/mean fitness, population spread,
+  and the current best pipeline drawn on the canvas.
+* Stop a run; the whole process tree is terminated.
+* Metrics are computed on a holdout split the composer never saw.
+
+Runs execute in their own process, so the API stays responsive and cancellation is
+reliable. Progress comes from GOLEM's `set_iteration_callback`, which fires as each
+generation is recorded — not from parsing logs, and not by waiting for the final history.
+
+## Configuration
+
+All settings are environment variables prefixed with `FEDOTWEB_`, or entries in a `.env`
+file.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `FEDOTWEB_WORKSPACE` | `~/.fedot-web` | datasets, run artefacts and the SQLite database |
+| `FEDOTWEB_HOST` / `FEDOTWEB_PORT` | `127.0.0.1` / `8000` | bind address |
+| `FEDOTWEB_MAX_CONCURRENT_RUNS` | `2` | how many compositions may run at once |
+| `FEDOTWEB_MAX_RUN_TIMEOUT_MINUTES` | `240` | ceiling on a run's time budget |
+| `FEDOTWEB_MAX_UPLOAD_MB` | `256` | largest accepted dataset |
+| `FEDOTWEB_CORS_ORIGINS` | Vite dev server | additional allowed origins |
+| `FEDOTWEB_STATIC_DIR` | `ui/dist` | built frontend to serve at `/` |
+| `FEDOTWEB_MONGO_URI` | unset | optional; SQLite is used when absent |
+
+## Tests
+
+```bash
+pytest backend/tests
+```
+
+`test_catalog.py` and `test_convert.py` are fast unit tests. `test_run_flow.py` is an
+end-to-end test that uploads a dataset and runs a real (short) composition; it takes
+about a minute.
+
+```bash
+cd ui && npm run typecheck && npm run build
+```
+
+## What changed from version 1
+
+| | v1 | v2 |
+| --- | --- | --- |
+| Backend | Flask 2.2 + flask-restx | FastAPI, OpenAPI, pydantic v2 |
+| Storage | MongoDB required to start | SQLite by default, Mongo optional |
+| Frontend | React 17, Material-UI v4, Redux, CRA | React 19, MUI v7, Zustand + TanStack Query, Vite |
+| Pipeline canvas | dagre-d3, zoom commented out | React Flow: zoom, pan, minimap, layout toggle |
+| Node rendering | circle labelled `name id:0` | card with category, tags and live hyperparameters |
+| Hyperparameters | free-text key/value pairs | typed controls bounded by FEDOT's search space |
+| Validation | `verify_pipeline` with no task | task-aware rules, readable messages |
+| Running FEDOT | only pre-seeded showcase cases | upload data and configure a run from the UI |
+| Progress | none | per-generation streaming over WebSocket |
+| History graph | dagre-d3, individuals labelled `ind_3_7` | layered genealogy, live during the run; click a node for its pipeline and hyperparameters |
+| Scripted runs | not possible — the GUI owned the run | `import fedotweb.autowatch` and your own script opens the GUI |
+| Mid-run control | none | population size, generations, budget, operator probabilities, graceful finish |
+| Objective detail | one averaged number | per-fold metrics, their mean and spread, plus the holdout |
+| Preprocessing | invisible | per-column source and final types, and every decision behind a change |
+| Sensitivity | not exposed | GOLEM's structural analysis on demand, per node and edge |
+| FEDOT | pinned to 0.7.3.1 | master, current node API |
+
+### Notes on the port
+
+* `PrimaryNode` / `SecondaryNode` are deprecated in current FEDOT; conversion now builds
+  `PipelineNode` in topological order. The previous implementation rebuilt parents
+  recursively and de-duplicated them by `descriptive_id`, which merged distinct nodes
+  that happened to look alike — a pipeline with two identical parallel branches came back
+  with the wrong topology. There is a regression test for this
+  (`test_identical_parallel_branches_are_not_merged`).
+* Flask's `@app.before_first_request`, used by the v1 app factory, was removed in
+  Flask 2.3 — one reason an in-place dependency bump was not viable.
+* Node dimensions and handle geometry are declared to React Flow up front rather than
+  measured, so edges are routed on the first render.
+
+## Why FEDOT is installed from master
+
+The **released** FEDOT 0.7.5 wheel on PyPI pins `thegolem==0.4.1` and calls
+`log.warning(..., raise_if_test=True, exc=error)` in several error paths — invalid
+fitness during evaluation, cache read failures. Neither GOLEM 0.4.1 nor 0.4.2 accepts
+those keywords, so they reach `logging.Logger._log` and raise `TypeError`. A composition
+then dies at the first pipeline that scores badly, which is an ordinary event during
+evolution, not a fatal one. It is invisible with the `fast_train` preset and reliably
+reproducible with `best_quality`.
+
+FEDOT **master** has removed those calls and requires `thegolem==0.4.2`, so installing
+from master fixes it:
+
+```bash
+pip install git+https://github.com/aimclub/FEDOT.git@master
+```
+
+`fedotweb/runs/worker.py` still carries a defensive shim (`_patch_logger_kwargs`) that
+folds unsupported logging keywords into the message text. On master it finds nothing to
+do; it exists so that a user who installs the PyPI release instead of master gets a
+warning rather than a dead run. It can be deleted once a release ships the fix.
+
+## Known limitations
+
+* FEDOT skips evolution entirely when the time budget is too small to evaluate a
+  generation. The run then returns the initial assumption; the UI says so explicitly in
+  the log, but there is no way to know the threshold before starting.
+* Authentication was dropped. v1 shipped a `guest`/`guest` account and a login page; v2
+  binds to localhost and has no user model. Do not expose it to a network as-is.

--- a/backend/examples/evolution_story_dataset.py
+++ b/backend/examples/evolution_story_dataset.py
@@ -1,0 +1,55 @@
+"""A dataset on which FEDOT's evolution has a real story to tell.
+
+On most tabular data the evolution history looks trivial, and for a reason:
+the initial assumptions already contain catboost, xgboost, lgbm, rf, logit and
+a gbm ensemble, each prefixed with data-appropriate preprocessing. There is
+usually nothing left to discover.
+
+This generator builds data where every one of those seeds is provably weak and
+the strong pipelines are several structural discoveries away:
+
+* the signal is a sum of two squared oblique projections, (w1.x)^2 + (w2.x)^2 —
+  linear models are blind to it (AUC ~0.51), and axis-aligned boosting is
+  myopic (~0.67), because no single feature carries the signal;
+* features are scale-corrupted by up to two orders of magnitude, so distance-
+  and gradient-based models additionally need a scaling node in front.
+
+Measured single-pipeline scores on a holdout (n=2000, p=24):
+
+    seeds: gbm_linear 0.671 | rf 0.662 | scaling->logit 0.513
+    rungs: scaling->poly_features->logit 0.735
+    top:   qda 0.873 | scaling->mlp 0.872
+
+Note: qda and mlp are tagged 'deprecated' and never enter preset candidate
+sets; pass them via `available_operations` to make the summit reachable.
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def make_evolution_story(n: int = 2000, p: int = 24, hidden: int = 2,
+                         noise: float = 0.35, scale_pow: float = 2.0,
+                         seed: int = 3) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    latent = rng.normal(size=(n, p))
+
+    score = np.zeros(n)
+    for _ in range(hidden):
+        direction = rng.normal(size=p)
+        direction /= np.linalg.norm(direction)
+        score += (latent @ direction) ** 2
+    score = score - np.median(score)
+    score += rng.normal(scale=noise * np.std(score), size=n)
+
+    features = latent * 10 ** rng.uniform(-scale_pow, scale_pow, size=p)
+    frame = pd.DataFrame({f"f{i}": features[:, i] for i in range(p)})
+    frame["target"] = (score > 0).astype(int)
+    return frame
+
+
+if __name__ == "__main__":
+    frame = make_evolution_story()
+    frame.to_csv("quadratic_signal.csv", index=False)
+    print(f"written quadratic_signal.csv: {frame.shape[0]} rows, "
+          f"{frame.shape[1] - 1} features, base rate {frame.target.mean():.2f}")

--- a/backend/examples/watch_a_script.py
+++ b/backend/examples/watch_a_script.py
@@ -1,0 +1,67 @@
+"""Run FEDOT from your own script and watch it in the browser.
+
+Two ways to do it. The first is one import::
+
+    python examples/watch_a_script.py
+
+The second is explicit, for when you want to name the run::
+
+    python examples/watch_a_script.py --explicit
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def make_dataset(path: Path) -> Path:
+    """A small separable classification problem, so the example runs quickly."""
+    rng = np.random.default_rng(11)
+    size = 600
+    x1, x2 = rng.normal(size=size), rng.normal(size=size)
+    score = 1.4 * x1 - 0.9 * x2 + rng.normal(scale=0.5, size=size)
+    frame = pd.DataFrame({"x1": x1, "x2": x2, "target": (score > 0).astype(int)})
+    frame.to_csv(path, index=False)
+    return path
+
+
+def automatic(data: Path) -> None:
+    """The GUI opens by itself; the script is otherwise ordinary FEDOT."""
+    from fedot import Fedot
+
+    import fedotweb.autowatch  # noqa: F401  -- the import is the whole integration
+
+    model = Fedot(problem="classification", timeout=5, preset="best_quality", seed=1)
+    model.fit(features=str(data), target="target")
+    print("done:", model.current_pipeline)
+
+
+def explicit(data: Path) -> None:
+    """The same thing, with the session in hand."""
+    from fedot import Fedot
+
+    from fedotweb import watch
+
+    with watch("scoring from a script") as session:
+        model = Fedot(
+            problem="classification",
+            timeout=5,
+            preset="best_quality",
+            seed=1,
+            optimizer=session.optimizer,
+        )
+        model.fit(features=str(data), target="target")
+        session.record_result(model)
+        print("done:", model.current_pipeline)
+
+
+if __name__ == "__main__":
+    dataset = make_dataset(Path(__file__).with_name("example_scoring.csv"))
+    if "--explicit" in sys.argv:
+        explicit(dataset)
+    else:
+        automatic(dataset)

--- a/backend/fedotweb/__init__.py
+++ b/backend/fedotweb/__init__.py
@@ -1,0 +1,20 @@
+"""FEDOT.Web — a web interface for the FEDOT AutoML framework and GOLEM.
+
+To watch a run you start yourself, see :func:`fedotweb.watch`, or simply
+``import fedotweb.autowatch`` and the GUI opens on the next ``fit``.
+"""
+
+__version__ = "2.1.0"
+
+
+def __getattr__(name: str):
+    # Imported lazily so that `import fedotweb` stays cheap for the server, which
+    # does not need the attach machinery.
+    if name in ("watch", "ensure_server", "WatchSession"):
+        from . import attach
+
+        return getattr(attach, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["WatchSession", "ensure_server", "watch"]

--- a/backend/fedotweb/__main__.py
+++ b/backend/fedotweb/__main__.py
@@ -1,0 +1,35 @@
+"""Command-line entry point: ``python -m fedotweb`` or ``fedot-web``."""
+
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+
+from .settings import get_settings
+
+
+def main() -> int:
+    settings = get_settings()
+
+    parser = argparse.ArgumentParser(prog="fedot-web", description="Run the FEDOT.Web server")
+    parser.add_argument("--host", default=settings.host)
+    parser.add_argument("--port", type=int, default=settings.port)
+    parser.add_argument("--reload", action="store_true", default=settings.reload)
+    arguments = parser.parse_args()
+
+    print(f"FEDOT.Web workspace: {settings.workspace}")
+    print(f"API docs: http://{arguments.host}:{arguments.port}/docs")
+
+    uvicorn.run(
+        "fedotweb.main:app",
+        host=arguments.host,
+        port=arguments.port,
+        reload=arguments.reload,
+        log_level="info",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/fedotweb/analysis/__init__.py
+++ b/backend/fedotweb/analysis/__init__.py
@@ -1,0 +1,5 @@
+"""On-demand analyses: where a score came from, and what it rests on."""
+
+from .manager import AnalysisError, AnalysisManager
+
+__all__ = ["AnalysisError", "AnalysisManager"]

--- a/backend/fedotweb/analysis/manager.py
+++ b/backend/fedotweb/analysis/manager.py
@@ -1,0 +1,119 @@
+"""Running on-demand analyses out of process and collecting their results."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from ..settings import Settings
+from ..storage.sqlite import Store
+from .worker import JOB_FILE, RESULT_FILE
+
+#: An analysis refits a pipeline many times; this stops a pathological one from
+#: holding a slot forever.
+DEFAULT_TIMEOUT_SECONDS = 1800.0
+
+
+class AnalysisError(RuntimeError):
+    """Raised when an analysis cannot be started."""
+
+
+class AnalysisManager:
+    """Spawns analysis workers and writes their results back to the store."""
+
+    def __init__(self, store: Store, settings: Settings) -> None:
+        self._store = store
+        self._settings = settings
+        self._tasks: dict[str, asyncio.Task] = {}
+
+    def job_dir(self, analysis_uid: str) -> Path:
+        return self._settings.workspace / "analyses" / analysis_uid
+
+    @property
+    def active(self) -> int:
+        return sum(1 for task in self._tasks.values() if not task.done())
+
+    async def start(
+        self,
+        *,
+        run_uid: str,
+        kind: str,
+        spec: dict[str, Any],
+        pipeline_uid: str | None,
+        options: dict[str, Any],
+    ) -> str:
+        if self.active >= self._settings.max_concurrent_runs:
+            raise AnalysisError(
+                f"Too many analyses in progress (limit is {self._settings.max_concurrent_runs})"
+            )
+
+        analysis_uid = self._store.create_analysis(
+            run_uid=run_uid, kind=kind, pipeline_uid=pipeline_uid, options=options
+        )
+        directory = self.job_dir(analysis_uid)
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / JOB_FILE).write_text(
+            json.dumps({**spec, "kind": kind}, ensure_ascii=False, default=str), encoding="utf-8"
+        )
+
+        self._tasks[analysis_uid] = asyncio.create_task(self._supervise(analysis_uid, directory))
+        return analysis_uid
+
+    async def _supervise(self, analysis_uid: str, directory: Path) -> None:
+        package_root = str(Path(__file__).resolve().parents[2])
+        log_file = (directory / "worker.log").open("w", encoding="utf-8")
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                "fedotweb.analysis.worker",
+                str(directory),
+                cwd=package_root,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+            )
+            try:
+                await asyncio.wait_for(process.wait(), timeout=DEFAULT_TIMEOUT_SECONDS)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                self._store.finish_analysis(
+                    analysis_uid,
+                    error=f"The analysis exceeded {DEFAULT_TIMEOUT_SECONDS / 60:g} minutes and was stopped",
+                )
+                return
+
+            payload = self._read_result(directory)
+            if payload is None:
+                self._store.finish_analysis(
+                    analysis_uid, error="The analysis produced no result; see worker.log"
+                )
+            elif "error" in payload:
+                self._store.finish_analysis(analysis_uid, error=payload["error"])
+            else:
+                self._store.finish_analysis(analysis_uid, result=payload["result"])
+        except Exception as exc:  # noqa: BLE001 - a failed analysis must not take the server down
+            self._store.finish_analysis(analysis_uid, error=f"{type(exc).__name__}: {exc}")
+        finally:
+            log_file.close()
+            self._tasks.pop(analysis_uid, None)
+
+    @staticmethod
+    def _read_result(directory: Path) -> dict[str, Any] | None:
+        path = directory / RESULT_FILE
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            return {"error": f"The analysis wrote an unreadable result: {exc}"}
+
+    async def shutdown(self) -> None:
+        for task in list(self._tasks.values()):
+            task.cancel()
+        self._tasks.clear()

--- a/backend/fedotweb/analysis/scoring.py
+++ b/backend/fedotweb/analysis/scoring.py
@@ -1,0 +1,54 @@
+"""The objective structural analysis scores candidate pipelines with.
+
+GOLEM's node and edge analyses fan out over a ``multiprocessing.Pool`` — even for
+a single job — so the objective is pickled and shipped to each worker. That rules
+out a closure, and it rules out defining this in the module executed with ``-m``,
+whose classes pickle against ``__main__``. Hence a plain, importable class.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+class HoldoutScorer:
+    """Fit a candidate pipeline on the training split, score it on the holdout.
+
+    Structural analysis refits the pipeline once per variant it tries, so a single
+    holdout keeps the cost linear in the number of variants; cross-validating each
+    one would multiply it by the fold count.
+    """
+
+    def __init__(
+        self,
+        train_data: Any,
+        holdout_data: Any,
+        metric_id: str,
+        validation_blocks: int | None = None,
+    ) -> None:
+        self.train_data = train_data
+        self.holdout_data = holdout_data
+        self.metric_id = metric_id
+        self.validation_blocks = validation_blocks
+
+    def __call__(self, graph: Any) -> float:
+        from fedot.core.pipelines.adapters import PipelineAdapter
+        from fedot.core.repository.metrics_repository import MetricsRepository
+
+        from .worker import metric_enum
+
+        metric = MetricsRepository.get_metric(metric_enum(self.metric_id))
+
+        # Structural analysis works in GOLEM's own graph space, so what arrives
+        # here is an `OptGraph`; it has to be restored before FEDOT can fit it.
+        # The analysis is still using the graph it handed over, hence the copy.
+        candidate = PipelineAdapter().restore(deepcopy(graph))
+        try:
+            candidate.fit(self.train_data)
+            return float(metric(candidate, self.holdout_data, self.validation_blocks))
+        finally:
+            try:
+                candidate.unfit()
+            except Exception:
+                pass

--- a/backend/fedotweb/analysis/worker.py
+++ b/backend/fedotweb/analysis/worker.py
@@ -1,0 +1,437 @@
+"""On-demand analyses of a pipeline: where its score came from, and what it rests on.
+
+Both analyses here refit pipelines, which is CPU-bound and can take a while, so
+they run in their own process exactly as a composition does.
+
+Run as::
+
+    python -m fedotweb.analysis.worker <job_directory>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+JOB_FILE = "job.json"
+RESULT_FILE = "result.json"
+
+#: Metrics reported alongside the one the run optimised, so a score can be read
+#: in more than one currency.
+COMPANION_METRICS = {
+    "classification": ["roc_auc", "accuracy", "f1", "neg_log_loss"],
+    "regression": ["rmse", "mae", "r2"],
+    "ts_forecasting": ["rmse", "mae", "smape"],
+}
+
+
+def metric_enum(metric_id: str):
+    """Resolve a metric name to the enum member FEDOT indexes its registry by."""
+    from fedot.core.repository.metrics_repository import (
+        ClassificationMetricsEnum,
+        ClusteringMetricsEnum,
+        ComplexityMetricsEnum,
+        RegressionMetricsEnum,
+        TimeSeriesForecastingMetricsEnum,
+    )
+
+    for enum in (
+        ClassificationMetricsEnum,
+        RegressionMetricsEnum,
+        TimeSeriesForecastingMetricsEnum,
+        ClusteringMetricsEnum,
+        ComplexityMetricsEnum,
+    ):
+        try:
+            return enum(metric_id)
+        except ValueError:
+            continue
+    return None
+
+
+def _is_maximised(metric_enum) -> bool:
+    """Whether FEDOT negates this metric to turn it into something to minimise.
+
+    ``from_maximised_metric`` wraps the metric with ``functools.wraps``, so the
+    wrapper carries ``__wrapped__`` and metrics that are already minimised do not.
+    """
+    from fedot.core.repository.metrics_repository import MetricsRepository
+
+    try:
+        metric_class = MetricsRepository.get_metric_class(metric_enum)
+    except KeyError:
+        return False
+    return hasattr(getattr(metric_class, "metric", None), "__wrapped__")
+
+
+def _metrics_for(problem: str, primary: str | None) -> list[str]:
+    ordered = list(COMPANION_METRICS.get(problem, []))
+    if primary and primary not in ordered:
+        ordered.insert(0, primary)
+    elif primary:
+        ordered.remove(primary)
+        ordered.insert(0, primary)
+    return ordered
+
+
+def _load_data(spec: dict[str, Any]):
+    """Load the run's dataset and split off the same holdout the run used."""
+    from fedot.core.data.data import InputData
+    from fedot.core.data.data_split import train_test_data_setup
+    from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
+
+    problem = spec["problem"]
+    target = spec.get("target") or "target"
+    path = Path(spec["dataset_path"])
+
+    task_params = (
+        TsForecastingParams(forecast_length=int(spec.get("forecast_length") or 30))
+        if problem == "ts_forecasting"
+        else None
+    )
+    task = Task(TaskTypesEnum(problem), task_params)
+
+    if problem == "ts_forecasting":
+        data = InputData.from_csv_time_series(file_path=path, task=task, target_column=target)
+        blocks = int(spec.get("validation_blocks") or 2)
+        train, holdout = train_test_data_setup(data, validation_blocks=blocks)
+        return train, holdout, blocks
+
+    data = InputData.from_csv(file_path=path, task=task, target_columns=target)
+    # ``seed or 42`` would turn a legitimate seed of 0 into 42 — and this split
+    # must reproduce the run worker's exactly, or the holdout stops being held out.
+    seed = spec.get("seed")
+    train, holdout = train_test_data_setup(
+        data,
+        split_ratio=1.0 - float(spec.get("holdout_fraction") or 0.2),
+        shuffle=True,
+        stratify=problem == "classification",
+        random_seed=42 if seed is None else int(seed),
+    )
+    return train, holdout, None
+
+
+def _evaluate(pipeline, data, metric_ids: list[str], validation_blocks: int | None) -> dict[str, Any]:
+    """Every requested metric for one fitted pipeline on one dataset."""
+    from fedot.core.repository.metrics_repository import MetricsRepository
+
+    scores: dict[str, Any] = {}
+    for metric_id in metric_ids:
+        enum = metric_enum(metric_id)
+        if enum is None:
+            continue
+        try:
+            value = float(MetricsRepository.get_metric(enum)(pipeline, data, validation_blocks))
+        except Exception:
+            # A metric that cannot be computed here (wrong number of classes, say)
+            # should not cost the whole breakdown.
+            scores[metric_id] = None
+            continue
+        if value != value:  # NaN
+            value = None
+        scores[metric_id] = value
+    return scores
+
+
+def _readable(metric_id: str, value: float | None) -> float | None:
+    """The metric as a person reads it, undoing FEDOT's negation for display."""
+    if value is None:
+        return None
+    enum = metric_enum(metric_id)
+    return -value if enum is not None and _is_maximised(enum) else value
+
+
+def objective_breakdown(spec: dict[str, Any]) -> dict[str, Any]:
+    """How the objective value was arrived at, fold by fold.
+
+    FEDOT averages the per-fold metrics and keeps only the average -- that average
+    is the fitness evolution compares individuals by. The folds behind it are
+    discarded, so they are recomputed here on the same split the composer used.
+    """
+    from copy import deepcopy
+
+    from fedot.core.optimisers.objective.data_source_splitter import DataSourceSplitter
+
+    from ..pipelines.convert import graph_to_pipeline
+
+    train, holdout, validation_blocks = _load_data(spec)
+    metric_ids = _metrics_for(spec["problem"], spec.get("metric"))
+    cv_folds = int(spec.get("cv_folds") or 5)
+    template = graph_to_pipeline(spec["graph"])
+
+    # The composer builds its folds exactly this way; matching it is what makes
+    # the average below equal the fitness the run actually saw.
+    producer = DataSourceSplitter(cv_folds, shuffle=True).build(train)
+
+    folds: list[dict[str, Any]] = []
+    for fold_id, (fold_train, fold_test) in enumerate(producer()):
+        pipeline = deepcopy(template)
+        try:
+            pipeline.fit(fold_train)
+            scores = _evaluate(pipeline, fold_test, metric_ids, validation_blocks)
+            folds.append(
+                {
+                    "fold": fold_id,
+                    "train_size": int(len(fold_train.idx)),
+                    "test_size": int(len(fold_test.idx)),
+                    "metrics": scores,
+                    "readable": {k: _readable(k, v) for k, v in scores.items()},
+                    "failed": False,
+                }
+            )
+        except Exception as exc:
+            folds.append({"fold": fold_id, "failed": True, "error": str(exc), "metrics": {}})
+        finally:
+            pipeline.unfit()
+
+    # Mean over the folds that produced a value, per metric.
+    summary: dict[str, Any] = {}
+    for metric_id in metric_ids:
+        values = [
+            fold["metrics"].get(metric_id)
+            for fold in folds
+            if not fold["failed"] and fold["metrics"].get(metric_id) is not None
+        ]
+        if not values:
+            summary[metric_id] = None
+            continue
+        mean = sum(values) / len(values)
+        spread = max(values) - min(values)
+        summary[metric_id] = {
+            "mean": mean,
+            "readable_mean": _readable(metric_id, mean),
+            "min": min(values),
+            "max": max(values),
+            "spread": spread,
+            "folds_used": len(values),
+            "is_maximised": _is_maximised(metric_enum(metric_id)),
+        }
+
+    # And the same pipeline scored once on data neither evolution nor the folds saw.
+    holdout_scores: dict[str, Any] = {}
+    holdout_error: str | None = None
+    final = deepcopy(template)
+    try:
+        final.fit(train)
+        holdout_scores = _evaluate(final, holdout, metric_ids, validation_blocks)
+    except Exception as exc:
+        holdout_error = str(exc)
+    finally:
+        final.unfit()
+
+    return {
+        "kind": "objective",
+        "problem": spec["problem"],
+        "primary_metric": spec.get("metric") or metric_ids[0] if metric_ids else None,
+        "cv_folds": cv_folds,
+        "metrics": metric_ids,
+        "folds": folds,
+        "summary": summary,
+        "holdout": {
+            "size": int(len(holdout.idx)),
+            "metrics": holdout_scores,
+            "readable": {k: _readable(k, v) for k, v in holdout_scores.items()},
+            "error": holdout_error,
+        },
+        "note": (
+            "Fold metrics are what FEDOT averages into the objective value; the average "
+            "below is the fitness evolution compared pipelines by. Values are shown as "
+            "FEDOT computes them (negated for metrics it maximises) and, alongside, as "
+            "they read normally."
+        ),
+    }
+
+
+def sensitivity(spec: dict[str, Any]) -> dict[str, Any]:
+    """How much the pipeline's score depends on each node and edge.
+
+    Uses GOLEM's own structural analysis: each node is deleted, replaced and had
+    its subtree removed, each edge deleted and replaced, and the resulting change
+    in the objective is recorded.
+    """
+    from fedot.core.pipelines.adapters import PipelineAdapter
+    from golem.core.optimisers.objective import Objective
+    from golem.structural_analysis.graph_sa.edge_sa_approaches import (
+        EdgeDeletionAnalyze,
+        EdgeReplaceOperationAnalyze,
+    )
+    from golem.structural_analysis.graph_sa.graph_structural_analysis import GraphStructuralAnalysis
+    from golem.structural_analysis.graph_sa.node_sa_approaches import (
+        NodeDeletionAnalyze,
+        NodeReplaceOperationAnalyze,
+        SubtreeDeletionAnalyze,
+    )
+    from golem.structural_analysis.graph_sa.sa_requirements import StructuralAnalysisRequirements
+
+    from ..pipelines.convert import graph_to_pipeline
+    from .scoring import HoldoutScorer
+
+    train, holdout, validation_blocks = _load_data(spec)
+    metric_id = spec.get("metric") or _metrics_for(spec["problem"], None)[0]
+    enum = metric_enum(metric_id)
+    pipeline = graph_to_pipeline(spec["graph"])
+
+    objective = Objective({metric_id: HoldoutScorer(train, holdout, metric_id, validation_blocks)})
+
+    node_factory = _node_factory(spec)
+    replacements = int(spec.get("replacements") or 2)
+    requirements = StructuralAnalysisRequirements(
+        is_visualize=False,
+        is_save_results_to_json=False,
+        # Each replacement means another fit, so this is the main cost dial.
+        replacement_number_of_random_operations_nodes=replacements,
+        replacement_number_of_random_operations_edges=replacements,
+    )
+
+    approaches = [NodeDeletionAnalyze, NodeReplaceOperationAnalyze, SubtreeDeletionAnalyze]
+    if spec.get("analyse_edges", True):
+        approaches += [EdgeDeletionAnalyze, EdgeReplaceOperationAnalyze]
+
+    analysis = GraphStructuralAnalysis(
+        objective=objective,
+        node_factory=node_factory,
+        approaches=approaches,
+        requirements=requirements,
+        path_to_save=str(Path(spec["job_dir"]) / "sa"),
+    )
+    # The analysis and its node factory both work on GOLEM's graph representation,
+    # not on a FEDOT pipeline; the scorer restores it on the other side.
+    results = analysis.analyze(graph=PipelineAdapter().adapt(pipeline), n_jobs=1)
+
+    return {
+        "kind": "sensitivity",
+        "metric": metric_id,
+        "is_maximised": _is_maximised(enum),
+        "entities": _flatten_sa(results, pipeline),
+        "note": (
+            "GOLEM reports each change as a sign-normalised score ratio: above 1 means the "
+            "change improved the objective — that part is dead weight or replaceable — and "
+            "below 1 means it hurt, so the pipeline relies on the part. Exactly -1 marks a "
+            "change that could not be evaluated."
+        ),
+    }
+
+
+def _node_factory(spec: dict[str, Any]):
+    """The factory structural analysis uses when proposing replacements.
+
+    Restricted to the operations the run itself was allowed to use, so a proposed
+    replacement is one the composer could genuinely have chosen.
+    """
+    from fedot.core.pipelines.pipeline_composer_requirements import PipelineComposerRequirements
+    from fedot.core.pipelines.pipeline_node_factory import PipelineOptNodeFactory
+    from fedot.core.repository.operation_types_repository import get_operations_for_task
+    from fedot.core.repository.tasks import Task, TaskTypesEnum
+
+    task = Task(TaskTypesEnum(spec["problem"]))
+    available = spec.get("available_operations") or get_operations_for_task(task=task, mode="all")
+
+    requirements = PipelineComposerRequirements(
+        primary=list(available),
+        secondary=list(available),
+        cv_folds=None,
+    )
+    return PipelineOptNodeFactory(requirements=requirements)
+
+
+def _flatten_sa(results: Any, pipeline: Any) -> list[dict[str, Any]]:
+    """Turn GOLEM's nested analysis results into rows the UI can table and colour."""
+    from golem.structural_analysis.graph_sa.results.utils import EntityTypesEnum
+
+    rows: list[dict[str, Any]] = []
+    operations = [node.name for node in pipeline.nodes]
+
+    for iteration, per_type in (results.results_per_iteration or {}).items():
+        for entity_type in (EntityTypesEnum.node.value, EntityTypesEnum.edge.value):
+            for position, entity_result in enumerate(per_type.get(entity_type) or []):
+                approaches: dict[str, Any] = {}
+                for approach in getattr(entity_result, "result_approaches", []) or []:
+                    name = type(approach).__name__.replace("SAApproachResult", "")
+                    try:
+                        approaches[name] = approach.get_all_results()
+                    except Exception:
+                        approaches[name] = None
+
+                # GOLEM identifies a node by its index and an edge by "from_to",
+                # which is a surer key than the order results come back in.
+                entity = str(getattr(entity_result, "entity_idx", position))
+                operation = None
+                if entity_type == "node" and entity.isdigit() and int(entity) < len(operations):
+                    operation = operations[int(entity)]
+                elif entity_type == "edge":
+                    ends = [part for part in entity.split("_") if part.isdigit()]
+                    if len(ends) == 2:
+                        source, target = (int(end) for end in ends)
+                        if source < len(operations) and target < len(operations):
+                            operation = f"{operations[source]} → {operations[target]}"
+
+                # GOLEM's ratio is sign-normalised (see _compare_with_origin_by_metric):
+                # above 1 always means the change IMPROVED the objective, whichever
+                # way the metric points -- its own optimize() applies changes at
+                # value > 1. The verdict is decided here so no client has to
+                # rediscover that convention. Exactly -1 is GOLEM's could-not-
+                # evaluate sentinel.
+                worst = _worst_of(entity_result)
+                value = worst.get("value") if isinstance(worst, dict) else None
+                improves: bool | None = None
+                severity = 0.0
+                if isinstance(value, (int, float)) and value != -1.0:
+                    improves = value > 1
+                    severity = abs(value - 1)
+
+                rows.append(
+                    {
+                        "iteration": int(iteration),
+                        "entity_type": entity_type,
+                        "entity": entity,
+                        "operation": operation,
+                        "approaches": approaches,
+                        "worst": worst,
+                        "improves": improves,
+                        "severity": severity,
+                    }
+                )
+    return rows
+
+
+def _worst_of(entity_result: Any) -> dict[str, Any] | None:
+    try:
+        return entity_result.get_worst_result_with_names(metric_idx_to_optimize_by=0)
+    except Exception:
+        return None
+
+
+ANALYSES = {"objective": objective_breakdown, "sensitivity": sensitivity}
+
+
+def run(job_dir: Path) -> int:
+    spec: dict[str, Any] = json.loads((job_dir / JOB_FILE).read_text(encoding="utf-8"))
+    spec["job_dir"] = str(job_dir)
+
+    analyse = ANALYSES.get(spec.get("kind", ""))
+    if analyse is None:
+        payload = {"error": f"Unknown analysis: {spec.get('kind')}"}
+    else:
+        try:
+            payload = {"result": analyse(spec)}
+        except Exception as exc:
+            payload = {"error": f"{type(exc).__name__}: {exc}", "traceback": traceback.format_exc()}
+
+    (job_dir / RESULT_FILE).write_text(
+        json.dumps(payload, ensure_ascii=False, allow_nan=False, default=str), encoding="utf-8"
+    )
+    return 0 if "result" in payload else 1
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: python -m fedotweb.analysis.worker <job_directory>", file=sys.stderr)
+        return 2
+    return run(Path(sys.argv[1]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/fedotweb/api/analysis.py
+++ b/backend/fedotweb/api/analysis.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from ..analysis import AnalysisError, AnalysisManager
 from ..history import individual_pipeline, live_individual_pipeline
 from ..runs.manager import RunManager
-from ..schemas import AnalysisRecord, StartAnalysisRequest
+from ..schemas import AnalysisRecord, StandaloneAnalysisRequest, StartAnalysisRequest
 from ..storage.sqlite import Store
 from .deps import get_analysis_manager, get_manager, get_store
 
@@ -102,6 +102,51 @@ async def start_analysis(
             spec=spec,
             pipeline_uid=pipeline_uid,
             options=request.model_dump(),
+        )
+    except AnalysisError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    record = store.get_analysis(analysis_uid)
+    if record is None:  # pragma: no cover
+        raise HTTPException(status_code=500, detail="The analysis could not be created")
+    return AnalysisRecord(**record)
+
+
+@router.post("/analyses", response_model=AnalysisRecord, status_code=202)
+async def start_standalone_analysis(
+    request: StandaloneAnalysisRequest,
+    store: Store = Depends(get_store),
+    analyses: AnalysisManager = Depends(get_analysis_manager),
+) -> AnalysisRecord:
+    """Analyse a pipeline that belongs to no run - one drawn in the editor.
+
+    The pipeline is fitted on the chosen dataset as part of the analysis, so
+    this costs the same as the run-scoped variant plus nothing: that one refits
+    too, it merely knows the dataset without being told.
+    """
+    dataset = store.get_dataset(request.dataset_uid)
+    if dataset is None:
+        raise HTTPException(status_code=404, detail=f"Unknown dataset: {request.dataset_uid}")
+
+    spec: dict[str, Any] = {
+        "graph": request.graph.model_dump(),
+        "dataset_path": dataset["filename"],
+        "target": request.target or dataset.get("target"),
+        "problem": request.problem or dataset.get("task") or "classification",
+        "metric": request.metric,
+        "cv_folds": request.cv_folds,
+        "seed": request.seed,
+        "replacements": request.replacements,
+        "analyse_edges": request.analyse_edges,
+    }
+
+    try:
+        analysis_uid = await analyses.start(
+            run_uid="",
+            kind=request.kind,
+            spec=spec,
+            pipeline_uid=None,
+            options=request.model_dump(exclude={"graph"}),
         )
     except AnalysisError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/backend/fedotweb/api/analysis.py
+++ b/backend/fedotweb/api/analysis.py
@@ -1,0 +1,127 @@
+"""Endpoints for the analyses you ask for rather than get automatically."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..analysis import AnalysisError, AnalysisManager
+from ..history import individual_pipeline, live_individual_pipeline
+from ..runs.manager import RunManager
+from ..schemas import AnalysisRecord, StartAnalysisRequest
+from ..storage.sqlite import Store
+from .deps import get_analysis_manager, get_manager, get_store
+
+router = APIRouter(tags=["analysis"])
+
+
+def _resolve_graph(
+    request: StartAnalysisRequest,
+    run: dict[str, Any],
+    store: Store,
+    manager: RunManager,
+) -> tuple[dict[str, Any], str | None]:
+    """Find the pipeline to analyse: one that was named, or the run's best."""
+    if request.individual_uid:
+        path = manager.run_dir(run["uid"]) / "history.json"
+        described = None
+        if path.exists():
+            described = individual_pipeline(path, request.individual_uid)
+        if described is None:
+            described = live_individual_pipeline(
+                store.list_events(run["uid"], kinds=["population"]), request.individual_uid
+            )
+        if described is None:
+            raise HTTPException(
+                status_code=404, detail=f"No individual {request.individual_uid} in this run"
+            )
+        return described, None
+
+    pipeline_uid = request.pipeline_uid or run.get("best_pipeline")
+    if not pipeline_uid:
+        raise HTTPException(
+            status_code=409,
+            detail="This run has no pipeline to analyse yet",
+        )
+    stored = store.get_pipeline(pipeline_uid)
+    if stored is None:
+        raise HTTPException(status_code=404, detail=f"Unknown pipeline: {pipeline_uid}")
+    return stored["graph"], pipeline_uid
+
+
+@router.post("/runs/{uid}/analyses", response_model=AnalysisRecord, status_code=202)
+async def start_analysis(
+    uid: str,
+    request: StartAnalysisRequest,
+    store: Store = Depends(get_store),
+    manager: RunManager = Depends(get_manager),
+    analyses: AnalysisManager = Depends(get_analysis_manager),
+) -> AnalysisRecord:
+    """Start an analysis of one of the run's pipelines.
+
+    Both kinds refit the pipeline repeatedly, so they run out of process and are
+    polled for; the response comes back immediately with a job to watch.
+    """
+    run = store.get_run(uid)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+
+    dataset_uid = run.get("dataset_uid")
+    dataset = store.get_dataset(dataset_uid) if dataset_uid else None
+    if dataset is None:
+        raise HTTPException(
+            status_code=409,
+            detail="This run has no dataset on file, so its pipelines cannot be re-evaluated. "
+            "Runs attached from a script keep their data in the script.",
+        )
+
+    graph, pipeline_uid = _resolve_graph(request, run, store, manager)
+    config = run.get("config") or {}
+
+    spec: dict[str, Any] = {
+        "graph": graph,
+        "dataset_path": dataset["filename"],
+        "target": config.get("target") or dataset.get("target"),
+        "problem": config.get("problem") or dataset.get("task") or "classification",
+        "metric": config.get("metric"),
+        "cv_folds": config.get("cv_folds", 5),
+        "seed": config.get("seed"),
+        "holdout_fraction": config.get("holdout_fraction"),
+        "forecast_length": config.get("forecast_length"),
+        "validation_blocks": config.get("validation_blocks"),
+        "available_operations": config.get("available_operations"),
+        "replacements": request.replacements,
+        "analyse_edges": request.analyse_edges,
+    }
+
+    try:
+        analysis_uid = await analyses.start(
+            run_uid=uid,
+            kind=request.kind,
+            spec=spec,
+            pipeline_uid=pipeline_uid,
+            options=request.model_dump(),
+        )
+    except AnalysisError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    record = store.get_analysis(analysis_uid)
+    if record is None:  # pragma: no cover
+        raise HTTPException(status_code=500, detail="The analysis could not be created")
+    return AnalysisRecord(**record)
+
+
+@router.get("/runs/{uid}/analyses", response_model=list[AnalysisRecord])
+def list_analyses(uid: str, store: Store = Depends(get_store)) -> list[AnalysisRecord]:
+    if store.get_run(uid) is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+    return [AnalysisRecord(**record) for record in store.list_analyses(uid)]
+
+
+@router.get("/analyses/{analysis_uid}", response_model=AnalysisRecord)
+def get_analysis(analysis_uid: str, store: Store = Depends(get_store)) -> AnalysisRecord:
+    record = store.get_analysis(analysis_uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown analysis: {analysis_uid}")
+    return AnalysisRecord(**record)

--- a/backend/fedotweb/api/catalog.py
+++ b/backend/fedotweb/api/catalog.py
@@ -1,0 +1,104 @@
+"""Endpoints describing what FEDOT can do: operations, hyperparameters, presets."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from ..catalog import OperationCatalog
+from ..schemas import (
+    CapabilitiesResponse,
+    MetricInfo,
+    OperationDetail,
+    OperationSummary,
+    PresetInfo,
+    TaskInfo,
+)
+from ..settings import Settings, get_settings
+from .deps import get_operation_catalog
+
+router = APIRouter(tags=["catalog"])
+
+#: Quality metrics, grouped by the tasks they apply to.  Mirrors the enums in
+#: ``fedot.core.repository.metrics_repository``.
+METRICS: list[MetricInfo] = [
+    MetricInfo(id="roc_auc", label="ROC AUC", tasks=["classification"]),
+    MetricInfo(id="accuracy", label="Accuracy", tasks=["classification"]),
+    MetricInfo(id="f1", label="F1", tasks=["classification"]),
+    MetricInfo(id="precision", label="Precision", tasks=["classification"]),
+    MetricInfo(id="neg_log_loss", label="Log loss", tasks=["classification"]),
+    MetricInfo(id="rmse", label="RMSE", tasks=["regression", "ts_forecasting"]),
+    MetricInfo(id="mse", label="MSE", tasks=["regression", "ts_forecasting"]),
+    MetricInfo(id="mae", label="MAE", tasks=["regression", "ts_forecasting"]),
+    MetricInfo(id="mape", label="MAPE", tasks=["regression", "ts_forecasting"]),
+    MetricInfo(id="smape", label="SMAPE", tasks=["regression", "ts_forecasting"]),
+    MetricInfo(id="r2", label="R²", tasks=["regression", "ts_forecasting"]),
+    MetricInfo(id="mase", label="MASE", tasks=["ts_forecasting"]),
+    MetricInfo(id="node_number", label="Pipeline size (complexity)", tasks=[]),
+    MetricInfo(id="structural", label="Structural complexity", tasks=[]),
+]
+
+#: FEDOT presets trade composition time against the breadth of the search.
+PRESETS: list[PresetInfo] = [
+    PresetInfo(id="auto", label="Auto", description="Let FEDOT pick a preset from the data and the time budget"),
+    PresetInfo(id="fast_train", label="Fast train", description="Only cheap models — good for a first look"),
+    PresetInfo(id="best_quality", label="Best quality", description="The full operation set; needs a large budget"),
+    PresetInfo(id="stable", label="Stable", description="Operations that rarely fail on messy data"),
+    PresetInfo(id="ts", label="Time series", description="Operations tailored to forecasting"),
+    PresetInfo(id="gpu", label="GPU", description="Operations with GPU implementations"),
+]
+
+
+@router.get("/capabilities", response_model=CapabilitiesResponse)
+def capabilities(
+    catalog: OperationCatalog = Depends(get_operation_catalog),
+    settings: Settings = Depends(get_settings),
+) -> CapabilitiesResponse:
+    """Everything the run-configuration form needs, in one request."""
+    import fedot
+
+    golem_version: str | None = None
+    try:
+        from importlib.metadata import version
+
+        golem_version = version("thegolem")
+    except Exception:
+        golem_version = None
+
+    return CapabilitiesResponse(
+        fedot_version=getattr(fedot, "__version__", "unknown"),
+        golem_version=golem_version,
+        tasks=[TaskInfo(**task) for task in catalog.tasks()],
+        metrics=METRICS,
+        presets=PRESETS,
+        max_run_timeout_minutes=settings.max_run_timeout_minutes,
+        max_concurrent_runs=settings.max_concurrent_runs,
+    )
+
+
+@router.get("/operations", response_model=list[OperationSummary])
+def list_operations(
+    task: str | None = Query(default=None, description="Keep only operations supporting this task"),
+    kind: str | None = Query(default=None, description="'model' or 'data_operation'"),
+    include_non_default: bool = Query(default=True),
+    catalog: OperationCatalog = Depends(get_operation_catalog),
+) -> list[OperationSummary]:
+    """The operation palette."""
+    try:
+        operations = catalog.list_operations(
+            task=task, kind=kind, include_non_default=include_non_default
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return [OperationSummary(**operation) for operation in operations]
+
+
+@router.get("/operations/{operation_id}", response_model=OperationDetail)
+def get_operation(
+    operation_id: str,
+    catalog: OperationCatalog = Depends(get_operation_catalog),
+) -> OperationDetail:
+    """One operation with the typed schema of every hyperparameter it accepts."""
+    operation = catalog.get(operation_id)
+    if operation is None:
+        raise HTTPException(status_code=404, detail=f"Unknown operation: {operation_id}")
+    return OperationDetail(**operation)

--- a/backend/fedotweb/api/datasets.py
+++ b/backend/fedotweb/api/datasets.py
@@ -1,0 +1,190 @@
+"""Endpoints for uploading and inspecting datasets."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi.responses import Response
+
+from ..datasets.preprocessing import describe_preprocessing
+from ..datasets.service import DatasetError, inspect_csv, store_upload, suggest_target
+from ..schemas import DatasetRecord, DatasetUploadResult, PreprocessingReport
+from ..settings import Settings, get_settings
+from ..storage.sqlite import Store, new_uid, utcnow
+from .deps import get_store
+
+router = APIRouter(prefix="/datasets", tags=["datasets"])
+
+ALLOWED_SUFFIXES = {".csv", ".tsv", ".txt"}
+
+
+@router.get("", response_model=list[DatasetRecord])
+def list_datasets(store: Store = Depends(get_store)) -> list[DatasetRecord]:
+    return [DatasetRecord(**record) for record in store.list_datasets()]
+
+
+@router.post("", response_model=DatasetUploadResult, status_code=201)
+async def upload_dataset(
+    file: UploadFile = File(...),
+    name: str | None = Form(default=None),
+    task: str | None = Form(default=None),
+    target: str | None = Form(default=None),
+    store: Store = Depends(get_store),
+    settings: Settings = Depends(get_settings),
+) -> DatasetUploadResult:
+    """Accept a CSV, describe its columns and suggest a target."""
+    suffix = Path(file.filename or "").suffix.lower()
+    if suffix not in ALLOWED_SUFFIXES:
+        raise HTTPException(
+            status_code=415,
+            detail=f"Unsupported file type '{suffix or 'unknown'}'. Upload a CSV, TSV or TXT file.",
+        )
+
+    uid = new_uid()
+    limit_bytes = int(settings.max_upload_mb * 1024 * 1024)
+
+    # Stream to a temporary file first so an oversized upload never lands in the
+    # workspace, and so a failed inspection leaves nothing behind.
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as staging:
+        staged_path = Path(staging.name)
+        written = 0
+        while chunk := await file.read(1024 * 1024):
+            written += len(chunk)
+            if written > limit_bytes:
+                staging.close()
+                staged_path.unlink(missing_ok=True)
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"The file exceeds the {settings.max_upload_mb:g} MB upload limit",
+                )
+            staging.write(chunk)
+
+    try:
+        inspection = inspect_csv(staged_path)
+    except DatasetError as exc:
+        staged_path.unlink(missing_ok=True)
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    destination_dir = settings.datasets_dir / uid
+    try:
+        stored_path = store_upload(staged_path, destination_dir, file.filename or f"{uid}{suffix}")
+    except DatasetError as exc:
+        staged_path.unlink(missing_ok=True)
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    suggested = suggest_target(inspection["columns"])
+    record = {
+        "uid": uid,
+        "name": name or Path(file.filename or uid).stem,
+        "filename": str(stored_path),
+        "task": task,
+        "target": target or suggested,
+        "n_rows": inspection["n_rows"],
+        "n_columns": inspection["n_columns"],
+        "columns": inspection["columns"],
+        "created_at": utcnow(),
+    }
+    store.save_dataset(record)
+
+    return DatasetUploadResult(
+        **record,
+        preview=inspection["preview"],
+        suggested_target=suggested,
+    )
+
+
+@router.get("/{uid}", response_model=DatasetRecord)
+def get_dataset(uid: str, store: Store = Depends(get_store)) -> DatasetRecord:
+    record = store.get_dataset(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown dataset: {uid}")
+    return DatasetRecord(**record)
+
+
+@router.get("/{uid}/preview")
+def preview_dataset(uid: str, store: Store = Depends(get_store)) -> dict:
+    """Re-read the head of a stored dataset."""
+    record = store.get_dataset(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown dataset: {uid}")
+    try:
+        inspection = inspect_csv(Path(record["filename"]))
+    except DatasetError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return {"columns": inspection["columns"], "preview": inspection["preview"], "n_rows": inspection["n_rows"]}
+
+
+@router.get("/{uid}/preprocessing", response_model=PreprocessingReport)
+def preprocessing_report(
+    uid: str,
+    task: str | None = None,
+    target: str | None = None,
+    forecast_length: int = 30,
+    store: Store = Depends(get_store),
+) -> PreprocessingReport:
+    """What FEDOT's preprocessing does to this dataset, and the resulting types.
+
+    Runs the framework's own preprocessor rather than re-implementing its rules,
+    so what is reported is what a run would actually see.
+    """
+    record = store.get_dataset(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown dataset: {uid}")
+
+    problem = task or record.get("task") or "classification"
+    chosen_target = target or record.get("target")
+    if not chosen_target:
+        raise HTTPException(status_code=422, detail="No target column is set for this dataset")
+
+    try:
+        report = describe_preprocessing(
+            Path(record["filename"]),
+            problem=problem,
+            target=chosen_target,
+            forecast_length=forecast_length,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=422, detail=f"The dataset could not be preprocessed: {exc}"
+        ) from exc
+    return PreprocessingReport(**report)
+
+
+@router.patch("/{uid}", response_model=DatasetRecord)
+def update_dataset(
+    uid: str,
+    target: str | None = Form(default=None),
+    task: str | None = Form(default=None),
+    store: Store = Depends(get_store),
+) -> DatasetRecord:
+    record = store.get_dataset(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown dataset: {uid}")
+    if target is not None:
+        known = {column["name"] for column in record["columns"]}
+        if target not in known:
+            raise HTTPException(status_code=422, detail=f"Column '{target}' is not in this dataset")
+        record["target"] = target
+    if task is not None:
+        record["task"] = task
+    store.save_dataset(record)
+    return DatasetRecord(**record)
+
+
+@router.delete("/{uid}", status_code=204)
+def delete_dataset(
+    uid: str,
+    store: Store = Depends(get_store),
+    settings: Settings = Depends(get_settings),
+) -> Response:
+    record = store.get_dataset(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown dataset: {uid}")
+    store.delete_dataset(uid)
+    shutil.rmtree(settings.datasets_dir / uid, ignore_errors=True)
+    return Response(status_code=204)

--- a/backend/fedotweb/api/deps.py
+++ b/backend/fedotweb/api/deps.py
@@ -1,0 +1,57 @@
+"""Shared application state and FastAPI dependencies."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+from ..analysis import AnalysisManager
+from ..catalog import OperationCatalog, get_catalog
+from ..runs.manager import RunManager
+from ..settings import Settings, get_settings
+from ..storage.sqlite import Store
+
+
+class AppState:
+    """Objects with a process lifetime, created once during startup."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.store = Store(settings.database_path)
+        self.manager = RunManager(self.store, settings)
+        self.analyses = AnalysisManager(self.store, settings)
+        self._catalog: OperationCatalog | None = None
+
+    @property
+    def catalog(self) -> OperationCatalog:
+        # Building the catalogue imports FEDOT's repositories, which costs a second
+        # or two; defer it until something actually asks for operations.
+        if self._catalog is None:
+            self._catalog = get_catalog()
+        return self._catalog
+
+
+def build_state() -> AppState:
+    return AppState(get_settings())
+
+
+def get_state(request: Request) -> AppState:
+    state: AppState | None = getattr(request.app.state, "container", None)
+    if state is None:  # pragma: no cover - only reachable if startup failed
+        raise HTTPException(status_code=503, detail="Application state is not initialised")
+    return state
+
+
+def get_store(request: Request) -> Store:
+    return get_state(request).store
+
+
+def get_manager(request: Request) -> RunManager:
+    return get_state(request).manager
+
+
+def get_analysis_manager(request: Request) -> AnalysisManager:
+    return get_state(request).analyses
+
+
+def get_operation_catalog(request: Request) -> OperationCatalog:
+    return get_state(request).catalog

--- a/backend/fedotweb/api/pipelines.py
+++ b/backend/fedotweb/api/pipelines.py
@@ -1,0 +1,147 @@
+"""Endpoints for building, validating, storing and exporting pipelines."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse, Response
+
+from ..pipelines.convert import (
+    PipelineConversionError,
+    graph_to_pipeline,
+    pipeline_to_graph,
+    validate_graph,
+)
+from ..schemas import (
+    PipelineGraph,
+    PipelineRecord,
+    SavePipelineRequest,
+    ValidatePipelineRequest,
+    ValidationResult,
+)
+from ..storage.sqlite import Store
+from .deps import get_store
+
+router = APIRouter(prefix="/pipelines", tags=["pipelines"])
+
+
+@router.get("", response_model=list[PipelineRecord])
+def list_pipelines(
+    run_uid: str | None = Query(default=None),
+    store: Store = Depends(get_store),
+) -> list[PipelineRecord]:
+    return [PipelineRecord(**record) for record in store.list_pipelines(run_uid=run_uid)]
+
+
+@router.post("", response_model=PipelineRecord, status_code=201)
+def save_pipeline(request: SavePipelineRequest, store: Store = Depends(get_store)) -> PipelineRecord:
+    """Persist a pipeline drawn in the editor.
+
+    The graph is round-tripped through FEDOT first, so what comes back carries the
+    depth, length and node roles FEDOT itself computes rather than the editor's
+    guesses.
+    """
+    graph = request.graph.model_dump()
+    try:
+        pipeline = graph_to_pipeline(graph)
+    except PipelineConversionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    described = pipeline_to_graph(pipeline)
+    uid = store.save_pipeline(
+        graph=described,
+        name=request.name,
+        task=request.task,
+        origin="editor",
+        uid=request.uid,
+    )
+    record = store.get_pipeline(uid)
+    if record is None:  # pragma: no cover - the row was just written
+        raise HTTPException(status_code=500, detail="Pipeline could not be stored")
+    return PipelineRecord(**record)
+
+
+@router.post("/validate", response_model=ValidationResult)
+def validate(request: ValidatePipelineRequest) -> ValidationResult:
+    """Check a graph against FEDOT's own pipeline rules for the given task."""
+    graph = request.graph.model_dump()
+    is_valid, problems = validate_graph(graph, task=request.task)
+
+    depth = length = 0
+    if is_valid:
+        try:
+            pipeline = graph_to_pipeline(graph)
+            depth, length = pipeline.depth, pipeline.length
+        except PipelineConversionError:
+            pass
+
+    return ValidationResult(is_valid=is_valid, problems=problems, depth=depth, length=length)
+
+
+@router.post("/describe", response_model=PipelineGraph)
+def describe(graph: PipelineGraph) -> PipelineGraph:
+    """Enrich an editor graph with everything FEDOT knows about it.
+
+    Used when the user drops a node onto the canvas: the backend fills in the
+    operation's group, tags, defaults and the recomputed depth/length.
+    """
+    try:
+        pipeline = graph_to_pipeline(graph.model_dump())
+    except PipelineConversionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return PipelineGraph(**pipeline_to_graph(pipeline, uid=graph.uid))
+
+
+@router.get("/{uid}", response_model=PipelineRecord)
+def get_pipeline(uid: str, store: Store = Depends(get_store)) -> PipelineRecord:
+    record = store.get_pipeline(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown pipeline: {uid}")
+    return PipelineRecord(**record)
+
+
+@router.delete("/{uid}", status_code=204)
+def delete_pipeline(uid: str, store: Store = Depends(get_store)) -> Response:
+    if not store.delete_pipeline(uid):
+        raise HTTPException(status_code=404, detail=f"Unknown pipeline: {uid}")
+    return Response(status_code=204)
+
+
+@router.get("/{uid}/export")
+def export_pipeline(uid: str, store: Store = Depends(get_store)) -> JSONResponse:
+    """Download the pipeline in FEDOT's own JSON format.
+
+    The result can be fed straight back into ``Pipeline.load``, which is what
+    makes a pipeline built in the browser usable from a script.
+    """
+    record = store.get_pipeline(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown pipeline: {uid}")
+
+    try:
+        pipeline = graph_to_pipeline(record["graph"])
+        dumped, _ = pipeline.save()
+    except PipelineConversionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    payload = json.loads(dumped) if isinstance(dumped, str) else dumped
+    filename = f"{record['name'].replace(' ', '_')}.json"
+    return JSONResponse(
+        content=payload,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.post("/import", response_model=PipelineGraph)
+def import_pipeline(payload: dict) -> PipelineGraph:
+    """Load a pipeline saved by FEDOT (``Pipeline.save``) into the editor."""
+    from fedot.core.pipelines.pipeline import Pipeline
+
+    try:
+        pipeline = Pipeline()
+        pipeline.load(payload)
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"Not a valid FEDOT pipeline: {exc}") from exc
+
+    return PipelineGraph(**pipeline_to_graph(pipeline))

--- a/backend/fedotweb/api/runs.py
+++ b/backend/fedotweb/api/runs.py
@@ -22,6 +22,7 @@ from ..runs.control import read_controls, write_controls
 from ..runs.manager import RunError, RunManager
 from ..schemas import (
     EffectiveParams,
+    EvaluationState,
     EvolutionControls,
     GenerationPoint,
     IndividualPipeline,
@@ -128,6 +129,25 @@ def get_run(uid: str, store: Store = Depends(get_store)) -> RunRecord:
     if record is None:
         raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
     return RunRecord(**record)
+
+
+@router.get("/{uid}/evaluations", response_model=EvaluationState)
+def get_evaluations(
+    uid: str,
+    store: Store = Depends(get_store),
+    manager: RunManager = Depends(get_manager),
+) -> EvaluationState:
+    """What the evaluator is doing right now: pipelines, folds and node fits.
+
+    Assembled from the trace files the evaluation processes write, so it works
+    the same for runs the GUI launched and for runs attached from a script.
+    """
+    if store.get_run(uid) is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+
+    from ..runs.evaltrace import read_evaluation_state
+
+    return EvaluationState(**read_evaluation_state(manager.run_dir(uid)))
 
 
 @router.get("/{uid}/progress", response_model=RunProgress)

--- a/backend/fedotweb/api/runs.py
+++ b/backend/fedotweb/api/runs.py
@@ -8,7 +8,7 @@ import shutil
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 
 from ..analysis import AnalysisManager
 from ..history import (
@@ -52,6 +52,7 @@ def _generation_points(events: list[dict[str, Any]]) -> list[GenerationPoint]:
         if event["kind"] != "generation":
             continue
         payload = event["payload"]
+        best = payload.get("best_pipeline") or {}
         points.append(
             GenerationPoint(
                 generation=payload.get("generation", len(points)),
@@ -59,6 +60,10 @@ def _generation_points(events: list[dict[str, Any]]) -> list[GenerationPoint]:
                 best_fitness=payload.get("best_fitness"),
                 mean_fitness=payload.get("mean_fitness"),
                 worst_fitness=payload.get("worst_fitness"),
+                best_uid=str(best.get("uid") or "") or None,
+                best_operations=[
+                    str(node.get("operation") or "") for node in (best.get("nodes") or [])
+                ],
             )
         )
     return points
@@ -174,9 +179,15 @@ def get_history(uid: str, manager: RunManager = Depends(get_manager)) -> dict:
     if not path.exists():
         raise HTTPException(status_code=404, detail="No history was saved for this run")
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise HTTPException(status_code=422, detail=f"The stored history is unreadable: {exc}") from exc
+    # The attachment header lets a plain link in the UI save the file under a
+    # sensible name; programmatic clients are unaffected.
+    return JSONResponse(
+        content=payload,
+        headers={"Content-Disposition": f'attachment; filename="opt_history_{uid}.json"'},
+    )
 
 
 @router.get("/{uid}/lineage", response_model=LineageGraph)

--- a/backend/fedotweb/api/runs.py
+++ b/backend/fedotweb/api/runs.py
@@ -1,0 +1,434 @@
+"""Endpoints that drive the framework: start, watch and stop AutoML runs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
+from fastapi.responses import Response
+
+from ..analysis import AnalysisManager
+from ..history import (
+    HistoryUnavailable,
+    individual_pipeline,
+    lineage_graph,
+    live_individual_pipeline,
+    live_lineage_graph,
+)
+from ..runs.control import read_controls, write_controls
+from ..runs.manager import RunError, RunManager
+from ..schemas import (
+    EffectiveParams,
+    EvolutionControls,
+    GenerationPoint,
+    IndividualPipeline,
+    LineageGraph,
+    PipelineGraph,
+    RunControlState,
+    RunEvent,
+    RunProgress,
+    RunRecord,
+    StartRunRequest,
+)
+from ..settings import Settings, get_settings
+from ..storage.sqlite import Store, utcnow
+from .deps import get_analysis_manager, get_manager, get_store
+
+router = APIRouter(prefix="/runs", tags=["runs"])
+
+#: How often the progress socket looks for new events when nothing wakes it.
+WS_POLL_SECONDS = 0.5
+
+#: Idle time after which the socket sends a keep-alive frame.
+WS_PING_SECONDS = 20.0
+
+
+def _generation_points(events: list[dict[str, Any]]) -> list[GenerationPoint]:
+    points: list[GenerationPoint] = []
+    for event in events:
+        if event["kind"] != "generation":
+            continue
+        payload = event["payload"]
+        points.append(
+            GenerationPoint(
+                generation=payload.get("generation", len(points)),
+                size=payload.get("size", 0),
+                best_fitness=payload.get("best_fitness"),
+                mean_fitness=payload.get("mean_fitness"),
+                worst_fitness=payload.get("worst_fitness"),
+            )
+        )
+    return points
+
+
+@router.get("", response_model=list[RunRecord])
+def list_runs(store: Store = Depends(get_store)) -> list[RunRecord]:
+    return [RunRecord(**record) for record in store.list_runs()]
+
+
+@router.post("", response_model=RunRecord, status_code=202)
+async def start_run(
+    request: StartRunRequest,
+    store: Store = Depends(get_store),
+    manager: RunManager = Depends(get_manager),
+    settings: Settings = Depends(get_settings),
+) -> RunRecord:
+    """Configure and launch a FEDOT composition."""
+    config = request.config
+
+    dataset = store.get_dataset(config.dataset_uid)
+    if dataset is None:
+        raise HTTPException(status_code=404, detail=f"Unknown dataset: {config.dataset_uid}")
+
+    target = config.target or dataset.get("target")
+    if not target:
+        raise HTTPException(status_code=422, detail="No target column was selected for this dataset")
+    known_columns = {column["name"] for column in dataset["columns"]}
+    if target not in known_columns:
+        raise HTTPException(status_code=422, detail=f"Column '{target}' is not in the dataset")
+
+    if config.timeout > settings.max_run_timeout_minutes:
+        raise HTTPException(
+            status_code=422,
+            detail=f"The time budget exceeds the server limit of {settings.max_run_timeout_minutes:g} minutes",
+        )
+
+    worker_config = config.model_dump(exclude_none=True)
+    worker_config["dataset_path"] = dataset["filename"]
+    worker_config["target"] = target
+    if config.initial_pipeline is not None:
+        worker_config["initial_pipeline"] = config.initial_pipeline.model_dump()
+
+    name = request.name or f"{config.problem} on {dataset['name']}"
+    run_uid = store.create_run(name=name, dataset_uid=config.dataset_uid, config=worker_config)
+
+    try:
+        await manager.start(run_uid, worker_config)
+    except RunError as exc:
+        store.update_run(run_uid, status="failed", error=str(exc))
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    record = store.get_run(run_uid)
+    if record is None:  # pragma: no cover
+        raise HTTPException(status_code=500, detail="The run could not be created")
+    return RunRecord(**record)
+
+
+@router.get("/{uid}", response_model=RunRecord)
+def get_run(uid: str, store: Store = Depends(get_store)) -> RunRecord:
+    record = store.get_run(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+    return RunRecord(**record)
+
+
+@router.get("/{uid}/progress", response_model=RunProgress)
+def get_progress(uid: str, store: Store = Depends(get_store)) -> RunProgress:
+    """A snapshot of the run: status, the fitness curve so far and the best pipeline."""
+    record = store.get_run(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+
+    # Population events carry whole pipelines; the progress snapshot needs none of that.
+    events = store.list_events(uid, kinds=["generation"])
+    generations = _generation_points(events)
+
+    best_graph: PipelineGraph | None = None
+    if record["best_pipeline"]:
+        stored = store.get_pipeline(record["best_pipeline"])
+        if stored:
+            best_graph = PipelineGraph(**stored["graph"])
+    else:
+        # While the run is live the best pipeline comes from the latest generation.
+        for event in reversed(events):
+            if event["kind"] == "generation" and event["payload"].get("best_pipeline"):
+                best_graph = PipelineGraph(**event["payload"]["best_pipeline"])
+                break
+
+    return RunProgress(
+        run=RunRecord(**record),
+        generations=generations,
+        best_pipeline=best_graph,
+        last_event_id=events[-1]["id"] if events else 0,
+    )
+
+
+@router.get("/{uid}/events", response_model=list[RunEvent])
+def get_events(
+    uid: str,
+    after_id: int = Query(default=0, ge=0),
+    store: Store = Depends(get_store),
+) -> list[RunEvent]:
+    if store.get_run(uid) is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+    return [RunEvent(**event) for event in store.list_events(uid, after_id=after_id)]
+
+
+@router.get("/{uid}/history")
+def get_history(uid: str, manager: RunManager = Depends(get_manager)) -> dict:
+    """The full GOLEM optimisation history, as saved by the worker."""
+    path = manager.run_dir(uid) / "history.json"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="No history was saved for this run")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=422, detail=f"The stored history is unreadable: {exc}") from exc
+
+
+@router.get("/{uid}/lineage", response_model=LineageGraph)
+def get_lineage(
+    uid: str,
+    full: bool = Query(
+        default=False,
+        description="Include every individual, not only the ancestry of the best pipeline",
+    ),
+    store: Store = Depends(get_store),
+    manager: RunManager = Depends(get_manager),
+) -> LineageGraph:
+    """The evolution history as a graph.
+
+    Individuals and the operators that produced them, laid out generation by
+    generation, so the descent of the best pipeline is visible.
+
+    A finished run is read from its saved history. A run still in progress has no
+    history file yet, so the graph is assembled from the progress events instead
+    -- which is what makes this usable for watching a composition as it happens.
+    """
+    if store.get_run(uid) is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+
+    path = manager.run_dir(uid) / "history.json"
+    try:
+        if path.exists():
+            return LineageGraph(**lineage_graph(path, only_winning_path=not full))
+    except (ValueError, KeyError, TypeError) as exc:
+        raise HTTPException(
+            status_code=422, detail=f"The stored history could not be interpreted: {exc}"
+        ) from exc
+
+    graph = live_lineage_graph(
+        store.list_events(uid, kinds=["population"]), only_winning_path=not full
+    )
+    if graph is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No generation has been reported for this run yet",
+        )
+    return LineageGraph(**graph)
+
+
+@router.get("/{uid}/lineage/{individual_uid}", response_model=IndividualPipeline)
+def get_lineage_pipeline(
+    uid: str,
+    individual_uid: str,
+    store: Store = Depends(get_store),
+    manager: RunManager = Depends(get_manager),
+) -> IndividualPipeline:
+    """The pipeline of one individual in the genealogy, live or finished."""
+    if store.get_run(uid) is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+
+    path = manager.run_dir(uid) / "history.json"
+    described = None
+    if path.exists():
+        try:
+            described = individual_pipeline(path, individual_uid)
+        except HistoryUnavailable:
+            described = None
+
+    if described is None:
+        described = live_individual_pipeline(
+            store.list_events(uid, kinds=["population"]), individual_uid
+        )
+
+    if described is None:
+        raise HTTPException(status_code=404, detail=f"No individual {individual_uid} in this run")
+    return IndividualPipeline(**described)
+
+
+def _control_state(uid: str, store: Store, manager: RunManager) -> RunControlState:
+    record = store.get_run(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+
+    requested = read_controls(manager.run_dir(uid))
+
+    effective = None
+    applied: list[str] = []
+    for event in reversed(store.list_events(uid, kinds=["effective_params", "control_applied"])):
+        if effective is None and event["kind"] == "effective_params":
+            effective = EffectiveParams(**event["payload"])
+        elif not applied and event["kind"] == "control_applied":
+            applied = list(event["payload"].get("changes") or [])
+        if effective is not None and applied:
+            break
+
+    return RunControlState(
+        requested=EvolutionControls(**requested.as_dict()),
+        effective=effective,
+        can_control=record["status"] in {"pending", "running"},
+        applied=applied,
+    )
+
+
+@router.get("/{uid}/controls", response_model=RunControlState)
+def get_controls(
+    uid: str,
+    store: Store = Depends(get_store),
+    manager: RunManager = Depends(get_manager),
+) -> RunControlState:
+    """What has been asked for, and what the optimiser is currently using."""
+    return _control_state(uid, store, manager)
+
+
+@router.patch("/{uid}/controls", response_model=RunControlState)
+def update_controls(
+    uid: str,
+    patch: dict,
+    store: Store = Depends(get_store),
+    manager: RunManager = Depends(get_manager),
+) -> RunControlState:
+    """Change how the evolution behaves, without restarting it.
+
+    The request is recorded for the worker, which picks it up between generations
+    -- a generation in flight is never disturbed. Fields left out keep their
+    current value; a field set to ``null`` hands that parameter back to GOLEM's
+    own adaptive policy.
+    """
+    record = store.get_run(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+    if record["status"] not in {"pending", "running"}:
+        raise HTTPException(
+            status_code=409, detail="This run has finished; there is nothing left to control"
+        )
+
+    write_controls(manager.run_dir(uid), patch)
+    return _control_state(uid, store, manager)
+
+
+@router.post("/{uid}/stop", response_model=RunRecord)
+async def stop_run(
+    uid: str,
+    store: Store = Depends(get_store),
+    manager: RunManager = Depends(get_manager),
+) -> RunRecord:
+    record = store.get_run(uid)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+
+    if await manager.cancel(uid):
+        return RunRecord(**(store.get_run(uid) or record))
+
+    if record["status"] in {"pending", "running"}:
+        # No worker of ours to kill, yet the run reads as live: it is driven by an
+        # external process (a script that attached), or that process died without
+        # saying so. Leave a graceful-finish request for a script that is still
+        # alive, and mark the record so it stops showing as running forever.
+        write_controls(manager.run_dir(uid), {"finish_now": True})
+        store.update_run(
+            uid,
+            status="cancelled",
+            finished_at=utcnow(),
+            error="Stopped from the GUI; a script attached to this run may still be finishing",
+        )
+        return RunRecord(**(store.get_run(uid) or record))
+
+    raise HTTPException(status_code=409, detail="This run is not in progress")
+
+
+@router.delete("/{uid}", status_code=204)
+async def delete_run(
+    uid: str,
+    store: Store = Depends(get_store),
+    manager: RunManager = Depends(get_manager),
+    analyses: AnalysisManager = Depends(get_analysis_manager),
+) -> Response:
+    if store.get_run(uid) is None:
+        raise HTTPException(status_code=404, detail=f"Unknown run: {uid}")
+    if manager.is_running(uid):
+        raise HTTPException(status_code=409, detail="Stop the run before deleting it")
+    # Analysis job directories are keyed by analysis uid, so collect them before
+    # the rows (and the uids with them) are gone.
+    for analysis in store.list_analyses(uid):
+        shutil.rmtree(analyses.job_dir(analysis["uid"]), ignore_errors=True)
+    store.delete_run(uid)
+    shutil.rmtree(manager.run_dir(uid), ignore_errors=True)
+    return Response(status_code=204)
+
+
+@router.websocket("/{uid}/stream")
+async def stream_run(websocket: WebSocket, uid: str) -> None:
+    """Push evolution progress to the browser as it happens."""
+    await websocket.accept()
+    state = getattr(websocket.app.state, "container", None)
+    if state is None:  # pragma: no cover
+        await websocket.close(code=1011)
+        return
+
+    store, manager = state.store, state.manager
+    if store.get_run(uid) is None:
+        await websocket.send_json({"kind": "error", "payload": {"message": f"Unknown run: {uid}"}})
+        await websocket.close(code=1008)
+        return
+
+    queue = manager.subscribe(uid)
+    last_id = 0
+    last_status: str | None = None
+    idle_ticks = 0
+
+    async def flush_new_events() -> None:
+        """Send everything stored since the last send. The store is the truth.
+
+        Reading from the store rather than only from the manager's queue is what
+        lets a run started outside the GUI stream too: an attached script writes
+        its events straight to the database and has no manager process to publish
+        through.
+        """
+        nonlocal last_id
+        for event in store.list_events(uid, after_id=last_id):
+            await websocket.send_json(event)
+            last_id = max(last_id, int(event.get("id") or 0))
+
+    try:
+        # Replay what already happened so a client that connects late, or
+        # reconnects, sees the whole curve.
+        await flush_new_events()
+
+        while True:
+            record = store.get_run(uid)
+            status = record["status"] if record else None
+            if status != last_status:
+                last_status = status
+                await websocket.send_json({"kind": "run_status", "payload": {"status": status}})
+
+            try:
+                # The queue is only a wake-up hint; whatever it carries is read
+                # back from the store so ordering and ids stay consistent.
+                await asyncio.wait_for(queue.get(), timeout=WS_POLL_SECONDS)
+                idle_ticks = 0
+            except asyncio.TimeoutError:
+                idle_ticks += 1
+
+            await flush_new_events()
+
+            if status in {"finished", "failed", "cancelled"}:
+                # Nothing more will arrive; keep the socket open but quiet so the
+                # client can decide when to close it.
+                await websocket.send_json({"kind": "ping", "payload": {}})
+                return
+
+            if idle_ticks * WS_POLL_SECONDS >= WS_PING_SECONDS:
+                # A periodic ping keeps intermediate proxies from closing an idle
+                # socket during a long generation.
+                idle_ticks = 0
+                await websocket.send_json({"kind": "ping", "payload": {}})
+    except (WebSocketDisconnect, RuntimeError):
+        # The client went away, or Starlette closed the socket underneath us.
+        pass
+    finally:
+        manager.unsubscribe(uid, queue)

--- a/backend/fedotweb/attach.py
+++ b/backend/fedotweb/attach.py
@@ -1,0 +1,279 @@
+"""Watch a FEDOT run that you started yourself.
+
+The rest of this package drives FEDOT from the browser. This module turns that
+round: you keep your own script, and the GUI attaches to it -- the server starts
+if it is not already up, a browser tab opens on the run's page, and every
+generation appears there as it happens, with the same live genealogy and the same
+controls for changing the evolution mid-flight.
+
+The whole of it::
+
+    import fedotweb.autowatch          # noqa: F401  -- opens the GUI on fit()
+
+    from fedot import Fedot
+    Fedot(problem='classification', timeout=10).fit(features=..., target=...)
+
+Or explicitly, when you want to name the run or keep the handle::
+
+    from fedotweb import watch
+
+    with watch('sea level forecast') as session:
+        model = Fedot(problem='ts_forecasting', timeout=10, optimizer=session.optimizer)
+        model.fit(train)
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+import webbrowser
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from .settings import get_settings
+from .storage.sqlite import Store, utcnow
+
+#: How long to wait for the background server to answer before giving up on it.
+SERVER_START_TIMEOUT = 30.0
+
+_server_lock = threading.Lock()
+_server_thread: threading.Thread | None = None
+
+
+def _port_is_open(host: str, port: int, timeout: float = 0.4) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(timeout)
+        return probe.connect_ex((host, port)) == 0
+
+
+def ensure_server(host: str | None = None, port: int | None = None) -> str:
+    """Start the FEDOT.Web server in this process if nothing is serving yet.
+
+    Returns the base URL. An already-running instance -- yours or someone else's
+    -- is reused, so several scripts can report into the same GUI.
+    """
+    settings = get_settings()
+    host = host or settings.host
+    port = port or settings.port
+
+    if _port_is_open(host, port):
+        return f"http://{host}:{port}"
+
+    global _server_thread
+    with _server_lock:
+        if _server_thread is None or not _server_thread.is_alive():
+            import uvicorn
+
+            from .main import create_app
+
+            config = uvicorn.Config(
+                create_app(), host=host, port=port, log_level="warning", access_log=False
+            )
+            server = uvicorn.Server(config)
+            # A daemon thread so the script can exit without joining it; the run
+            # is already persisted, so nothing is lost when the process ends.
+            _server_thread = threading.Thread(
+                target=server.run, name="fedot-web-server", daemon=True
+            )
+            _server_thread.start()
+
+    deadline = time.monotonic() + SERVER_START_TIMEOUT
+    while time.monotonic() < deadline:
+        if _port_is_open(host, port):
+            return f"http://{host}:{port}"
+        time.sleep(0.2)
+    raise RuntimeError(f"The FEDOT.Web server did not start on {host}:{port}")
+
+
+class WatchSession:
+    """A run started outside the GUI, reporting into it."""
+
+    def __init__(self, uid: str, url: str, store: Store, run_dir: Path) -> None:
+        self.uid = uid
+        self.url = url
+        self._store = store
+        self._run_dir = run_dir
+        self._started = time.monotonic()
+        self._optimizer_instance: Any = None
+        self._last_generation = 0
+
+    # ------------------------------------------------------------------- events
+
+    def emit(self, kind: str, **payload: Any) -> None:
+        self._store.append_event(self.uid, kind, payload)
+
+    # ---------------------------------------------------------------- optimizer
+
+    @property
+    def optimizer(self) -> type:
+        """Pass this to ``Fedot(optimizer=...)``.
+
+        It is an ``EvoGraphOptimizer`` that reports each generation into the GUI
+        and applies whatever controls the GUI has been asked for.
+        """
+        from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
+
+        from .runs.control import apply_controls, describe_effective, install_overrides, read_controls
+        from .runs.worker import describe_lineage, serialise_individual, summarise_population
+
+        session = self
+
+        def on_iteration(population, optimizer) -> None:
+            try:
+                generation = int(getattr(optimizer, "current_generation_num", 0))
+                members = list(population)
+                best_individuals = list(getattr(optimizer, "best_individuals", None) or [])
+                best = serialise_individual(best_individuals[0]) if best_individuals else None
+
+                session._last_generation = generation
+                session.emit(
+                    "generation",
+                    generation=generation,
+                    best_pipeline=best,
+                    **summarise_population(members),
+                )
+                session.emit(
+                    "population",
+                    generation=generation,
+                    individuals=describe_lineage(members),
+                    best_uids=[str(individual.uid) for individual in best_individuals],
+                )
+            except Exception as exc:  # reporting must never disturb the run
+                session.emit("log", level="warning", message=f"progress callback failed: {exc}")
+
+            try:
+                changes = apply_controls(optimizer, read_controls(session._run_dir))
+                if changes:
+                    session.emit("control_applied", generation=session._last_generation, changes=changes)
+                session.emit("effective_params", **describe_effective(optimizer))
+            except Exception as exc:
+                session.emit("log", level="warning", message=f"could not apply controls: {exc}")
+
+        class AttachedOptimizer(EvoGraphOptimizer):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                install_overrides(self)
+                self.set_iteration_callback(on_iteration)
+                session._optimizer_instance = self
+                try:
+                    apply_controls(self, read_controls(session._run_dir))
+                except Exception:
+                    pass
+
+        return AttachedOptimizer
+
+    # ------------------------------------------------------------------ closing
+
+    def finish(self, error: str | None = None) -> None:
+        """Mark the run done and keep whatever the optimiser produced."""
+        history = getattr(self._optimizer_instance, "history", None)
+        if history is not None:
+            try:
+                (self._run_dir / "history.json").write_text(history.save(), encoding="utf-8")
+            except Exception as exc:
+                self.emit("log", level="warning", message=f"history not saved: {exc}")
+
+        if error:
+            self.emit("error", message=error)
+            self._store.update_run(self.uid, status="failed", error=error, finished_at=utcnow())
+        else:
+            self.emit("finished", generations=self._last_generation)
+            self._store.update_run(self.uid, status="finished", finished_at=utcnow())
+
+    def record_result(self, model: Any) -> None:
+        """Store the fitted pipeline and its metrics, if the model has them.
+
+        Optional: a run is perfectly readable without it, but calling this makes
+        the results panel show the same thing a GUI-started run would.
+        """
+        from .pipelines.convert import pipeline_to_graph
+
+        pipeline = getattr(model, "current_pipeline", None)
+        if pipeline is None:
+            return
+        try:
+            graph = pipeline_to_graph(pipeline)
+        except Exception as exc:
+            self.emit("log", level="warning", message=f"pipeline not stored: {exc}")
+            return
+
+        run = self._store.get_run(self.uid) or {}
+        pipeline_uid = self._store.save_pipeline(
+            graph=graph,
+            name=f"{run.get('name', 'run')} — best pipeline",
+            task=(run.get("config") or {}).get("problem"),
+            origin="attached",
+            run_uid=self.uid,
+        )
+        updates: dict[str, Any] = {"best_pipeline": pipeline_uid}
+
+        # `get_metrics` scores whatever `predict` last ran on. A script that only
+        # fitted has no test data, and FEDOT then returns a number that looks like
+        # a metric but means nothing -- so it is better to show none at all.
+        if getattr(model, "prediction", None) is not None:
+            try:
+                metrics = model.get_metrics()
+                updates["metrics"] = {
+                    str(name): float(value)
+                    for name, value in dict(metrics).items()
+                    if isinstance(value, (int, float)) and value == value
+                }
+            except Exception as exc:
+                self.emit("log", level="warning", message=f"metrics unavailable: {exc}")
+        else:
+            self.emit(
+                "log",
+                level="info",
+                message="No metrics: call predict() before record_result() to score the model",
+            )
+
+        self._store.update_run(self.uid, **updates)
+
+
+@contextmanager
+def watch(
+    name: str | None = None,
+    *,
+    open_browser: bool = True,
+    config: dict[str, Any] | None = None,
+) -> Iterator[WatchSession]:
+    """Attach the GUI to a FEDOT run you drive yourself.
+
+    Args:
+        name: what to call the run in the GUI.
+        open_browser: set ``False`` on a headless machine; the URL is still
+            printed and the run is still recorded.
+        config: extra facts about the run to show alongside it, e.g. the task.
+    """
+    settings = get_settings()
+    url = ensure_server()
+
+    store = Store(settings.database_path)
+    run_config = {"origin": "attached", **(config or {})}
+    uid = store.create_run(name=name or "Attached FEDOT run", dataset_uid=None, config=run_config)
+    store.update_run(uid, status="running", started_at=utcnow())
+
+    run_dir = settings.runs_dir / uid
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    session = WatchSession(uid, f"{url}/runs/{uid}", store, run_dir)
+    session.emit("status", status="attached", url=session.url)
+
+    print(f"FEDOT.Web is watching this run: {session.url}")
+    if open_browser:
+        try:
+            webbrowser.open(session.url)
+        except Exception:
+            # A machine without a browser is not a reason to fail the run.
+            pass
+
+    try:
+        yield session
+    except BaseException as exc:
+        session.finish(error=f"{type(exc).__name__}: {exc}")
+        raise
+    else:
+        session.finish()

--- a/backend/fedotweb/attach.py
+++ b/backend/fedotweb/attach.py
@@ -117,6 +117,7 @@ class WatchSession:
         from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
 
         from .runs.control import apply_controls, describe_effective, install_overrides, read_controls
+        from .runs.evaltrace import TracingObjectiveEvaluate
         from .runs.worker import describe_lineage, serialise_individual, summarise_population
 
         session = self
@@ -162,6 +163,12 @@ class WatchSession:
                     apply_controls(self, read_controls(session._run_dir))
                 except Exception:
                     pass
+
+            def optimise(self, objective):
+                # Same per-pipeline, per-fold trace as GUI-launched runs.
+                return super().optimise(
+                    TracingObjectiveEvaluate.wrap(objective, session._run_dir)
+                )
 
         return AttachedOptimizer
 
@@ -261,6 +268,12 @@ def watch(
 
     session = WatchSession(uid, f"{url}/runs/{uid}", store, run_dir)
     session.emit("status", status="attached", url=session.url)
+
+    # Trace node fits happening in this process from the very start, so the
+    # minutes FEDOT spends fitting the initial assumptions are not silence.
+    from .runs.evaltrace import begin_main_process_trace
+
+    begin_main_process_trace(run_dir)
 
     print(f"FEDOT.Web is watching this run: {session.url}")
     if open_browser:

--- a/backend/fedotweb/autowatch.py
+++ b/backend/fedotweb/autowatch.py
@@ -1,0 +1,90 @@
+"""Import this and the GUI opens by itself.
+
+::
+
+    import fedotweb.autowatch          # noqa: F401
+
+    from fedot import Fedot
+    Fedot(problem='classification', timeout=10).fit(features=..., target=...)
+
+The import wraps ``Fedot.fit`` so that every fit starts a watched session: the
+server comes up if it is not already running, a browser tab opens on the run, and
+the evolution is reported there as it happens.
+
+An explicit ``optimizer=`` argument is left alone -- if you passed your own, this
+gets out of the way rather than overriding it.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .attach import watch
+
+#: Set ``FEDOTWEB_AUTOWATCH_BROWSER=0`` on a headless machine; the run is still
+#: recorded and the URL still printed.
+_OPEN_BROWSER = os.getenv("FEDOTWEB_AUTOWATCH_BROWSER", "1") not in ("0", "false", "False")
+
+
+def _describe(model: Any) -> dict[str, Any]:
+    """A few facts about the run, for the GUI to show beside it."""
+    params = getattr(model, "params", None)
+    problem = None
+    try:
+        problem = str(getattr(params, "task", None).task_type.value)
+    except Exception:
+        problem = None
+
+    described: dict[str, Any] = {"origin": "attached"}
+    if problem:
+        described["problem"] = problem
+    for name in ("timeout", "preset", "pop_size", "num_of_generations"):
+        try:
+            value = params.get(name)
+        except Exception:
+            value = None
+        if value is not None:
+            described[name] = value
+    return described
+
+
+def install() -> None:
+    """Wrap ``Fedot.fit``. Calling this twice is harmless."""
+    from fedot.api.main import Fedot
+
+    if getattr(Fedot, "_fedotweb_autowatch", False):
+        return
+
+    original_init = Fedot.__init__
+    original_fit = Fedot.fit
+
+    def __init__(self, *args, **kwargs):
+        # Remember whether the caller chose an optimiser, so we know not to
+        # replace it. `Fedot` swallows unknown keys into composer params, so the
+        # flag has to be captured before the call.
+        self._fedotweb_user_optimizer = kwargs.get("optimizer") is not None
+        original_init(self, *args, **kwargs)
+
+    def fit(self, *args, **kwargs):
+        if getattr(self, "_fedotweb_watching", False):
+            return original_fit(self, *args, **kwargs)
+
+        name = kwargs.pop("watch_name", None)
+        with watch(name, open_browser=_OPEN_BROWSER, config=_describe(self)) as session:
+            self._fedotweb_watching = True
+            if not getattr(self, "_fedotweb_user_optimizer", False):
+                self.params.update(optimizer=session.optimizer)
+            try:
+                result = original_fit(self, *args, **kwargs)
+            finally:
+                self._fedotweb_watching = False
+            session.record_result(self)
+            return result
+
+    Fedot.__init__ = __init__
+    Fedot.fit = fit
+    Fedot._fedotweb_autowatch = True
+
+
+install()

--- a/backend/fedotweb/catalog/__init__.py
+++ b/backend/fedotweb/catalog/__init__.py
@@ -1,0 +1,6 @@
+"""Machine-readable description of what FEDOT can build pipelines out of."""
+
+from .hyperparams import HyperparameterCatalog
+from .operations import OperationCatalog, get_catalog
+
+__all__ = ["HyperparameterCatalog", "OperationCatalog", "get_catalog"]

--- a/backend/fedotweb/catalog/hyperparams.py
+++ b/backend/fedotweb/catalog/hyperparams.py
@@ -1,0 +1,280 @@
+"""Extraction of machine-readable hyperparameter schemas from FEDOT.
+
+FEDOT already knows, for every operation, which hyperparameters exist, what type
+they are and which values are admissible -- that knowledge lives in
+``PipelineSearchSpace`` (used by the tuner) and in ``default_operation_params.json``.
+The legacy web GUI ignored all of it and rendered every hyperparameter as a bare
+text field.  This module turns that knowledge into JSON so the UI can render a
+proper typed editor: a slider bounded by the real sampling scope for continuous
+parameters, an integer stepper for discrete ones, a dropdown for categorical ones.
+
+Three sources are merged per operation:
+
+* ``PipelineSearchSpace``            -- type, sampling scope, hyperopt distribution
+* ``DefaultOperationParamsRepository`` -- default value applied when the node is created
+* the operation repositories        -- tags, supported tasks, input/output data types
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from fedot.core.pipelines.tuning.search_space import PipelineSearchSpace
+from fedot.core.repository.default_params_repository import DefaultOperationParamsRepository
+from fedot.core.utils import NESTED_PARAMS_LABEL
+
+#: Distributions whose sampling scope is best explored on a logarithmic axis.
+LOG_SCALE_DISTRIBUTIONS = frozenset({"loguniform", "qloguniform", "lognormal"})
+
+#: ``hyperopt`` distributions that draw from an explicit list of options.
+CHOICE_DISTRIBUTIONS = frozenset({"choice"})
+
+
+def _distribution_name(dist: Any) -> str | None:
+    """Return the readable name of a ``hyperopt`` distribution callable.
+
+    ``hp.uniform`` and friends are defined as ``hp_uniform`` internally, so the
+    prefix is stripped to give the plain distribution name.
+    """
+    if dist is None:
+        return None
+    name = getattr(dist, "__name__", None)
+    if not name:
+        # ``functools.partial`` wrappers are used for a few operations.
+        inner = getattr(dist, "func", None)
+        name = getattr(inner, "__name__", None) if inner is not None else None
+    if not name:
+        return None
+    return name[3:] if name.startswith("hp_") else name
+
+
+def _literal_value(node: Any) -> Any:
+    """Unwrap a ``hyperopt`` literal node into a plain Python value.
+
+    Returns the node untouched when it is already a plain value.
+    """
+    obj = getattr(node, "obj", None)
+    if obj is not None and type(node).__name__ == "Literal":
+        return obj
+    return node
+
+
+def _choices_from_hyperopt(node: Any) -> list[Any] | None:
+    """Best-effort extraction of the option list from an ``hp.choice`` expression.
+
+    ``hp.choice(label, options)`` expands into a ``switch`` apply node whose
+    positional arguments are the label expression followed by one literal per
+    option.  Anything we cannot decode returns ``None`` so the caller can fall
+    back to treating the value as opaque.
+    """
+    pos_args = getattr(node, "pos_args", None)
+    if not pos_args or len(pos_args) < 2:
+        return None
+    options = []
+    for arg in pos_args[1:]:
+        value = _literal_value(arg)
+        if type(value).__name__ in {"Apply", "Literal"}:
+            return None
+        options.append(value)
+    return options
+
+
+def _is_hyperopt_expression(value: Any) -> bool:
+    return type(value).__name__ in {"Apply", "Literal"}
+
+
+def _json_safe(value: Any) -> Any:
+    """Make a value safe for ``json.dumps`` with ``allow_nan=False``.
+
+    FEDOT defaults contain ``inf``/``nan`` in a few places; JSON has no literal
+    for either, and the legacy backend worked around this by string-replacing
+    ``Infinity`` in already-serialised payloads.
+    """
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return None
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (str, int, bool)) or value is None:
+        return value
+    # numpy scalars and anything else exotic
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            return _json_safe(item())
+        except (ValueError, TypeError):
+            pass
+    return str(value)
+
+
+def _value_type(default: Any, param_type: str, choices: list[Any] | None) -> str:
+    """Infer the widget-level value type for a parameter."""
+    sample = default
+    if sample is None and choices:
+        sample = next((c for c in choices if c is not None), None)
+
+    if isinstance(sample, bool):
+        return "boolean"
+    if isinstance(sample, int):
+        return "integer"
+    if isinstance(sample, float):
+        return "number"
+    if isinstance(sample, str):
+        return "string"
+    if isinstance(sample, (list, tuple)):
+        return "array"
+    if isinstance(sample, dict):
+        return "object"
+
+    # No usable sample -- fall back to the declared search-space type.
+    if param_type == "discrete":
+        return "integer"
+    if param_type == "continuous":
+        return "number"
+    return "string"
+
+
+def _parse_nested_variants(scope: Any) -> list[dict[str, Any]]:
+    """Decode the ``nested_space`` entry used by operations such as ``glm``.
+
+    The scope is a list of dicts; each dict fixes some fields to literals and
+    leaves others as ``hp.choice`` expressions over sub-options.
+    """
+    variants: list[dict[str, Any]] = []
+    if not isinstance(scope, list):
+        return variants
+
+    for index, option in enumerate(scope):
+        if not isinstance(option, dict):
+            continue
+        fixed: dict[str, Any] = {}
+        options: dict[str, list[Any]] = {}
+        for key, value in option.items():
+            if _is_hyperopt_expression(value):
+                decoded = _choices_from_hyperopt(value)
+                if decoded is not None:
+                    options[key] = _json_safe(decoded)
+            else:
+                fixed[key] = _json_safe(value)
+        label = str(next(iter(fixed.values()), f"option {index + 1}"))
+        variants.append({"label": label, "fixed": fixed, "options": options})
+    return variants
+
+
+def _schema_from_search_space(name: str, spec: dict[str, Any]) -> dict[str, Any]:
+    """Convert one ``PipelineSearchSpace`` entry into a UI-ready parameter schema."""
+    param_type = spec.get("type", "categorical")
+    distribution = _distribution_name(spec.get("hyperopt-dist"))
+    raw_scope = spec.get("sampling-scope") or []
+
+    schema: dict[str, Any] = {
+        "name": name,
+        "type": param_type,
+        "tunable": True,
+        "distribution": distribution,
+        "log_scale": distribution in LOG_SCALE_DISTRIBUTIONS,
+        "default": None,
+        "minimum": None,
+        "maximum": None,
+        "choices": None,
+        "nested_variants": None,
+    }
+
+    if name == NESTED_PARAMS_LABEL:
+        # ``sampling-scope`` is wrapped in an extra list for choice distributions.
+        inner = raw_scope[0] if len(raw_scope) == 1 else raw_scope
+        schema["type"] = "nested"
+        schema["nested_variants"] = _parse_nested_variants(inner)
+        schema["value_type"] = "object"
+        return schema
+
+    if param_type == "categorical" or distribution in CHOICE_DISTRIBUTIONS:
+        # Choice scopes are given as ``[[option, option, ...]]``.
+        options = raw_scope[0] if len(raw_scope) == 1 and isinstance(raw_scope[0], (list, tuple)) else raw_scope
+        decoded = [_json_safe(o) for o in options if not _is_hyperopt_expression(o)]
+        schema["choices"] = decoded or None
+    elif len(raw_scope) >= 2:
+        low, high = raw_scope[0], raw_scope[1]
+        if isinstance(low, (int, float)) and isinstance(high, (int, float)):
+            schema["minimum"] = _json_safe(low)
+            schema["maximum"] = _json_safe(high)
+
+    schema["value_type"] = _value_type(None, schema["type"], schema.get("choices"))
+    return schema
+
+
+def _schema_from_default(name: str, value: Any) -> dict[str, Any]:
+    """Build a schema for a parameter that has a default but no search-space entry.
+
+    These are still editable -- they are simply not explored by the tuner -- so
+    the UI needs to know their type in order to render the right widget.
+    """
+    safe = _json_safe(value)
+    value_type = _value_type(safe, "categorical", None)
+    return {
+        "name": name,
+        "type": "boolean" if value_type == "boolean" else "free",
+        "tunable": False,
+        "distribution": None,
+        "log_scale": False,
+        "default": safe,
+        "minimum": None,
+        "maximum": None,
+        "choices": [True, False] if value_type == "boolean" else None,
+        "nested_variants": None,
+        "value_type": value_type,
+    }
+
+
+class HyperparameterCatalog:
+    """Merged view over FEDOT's search space and default-parameter repositories."""
+
+    def __init__(self) -> None:
+        self._search_space = PipelineSearchSpace().parameters_per_operation
+        self._defaults_repo = DefaultOperationParamsRepository()
+
+    @staticmethod
+    def _base_name(operation: str) -> str:
+        """Strip the ``/variant`` suffix some operation ids carry (e.g. ``lagged/1``)."""
+        return operation.split("/")[0]
+
+    @property
+    def operations_with_search_space(self) -> list[str]:
+        return sorted(self._search_space.keys())
+
+    def defaults_for(self, operation: str) -> dict[str, Any]:
+        """Default hyperparameter values FEDOT applies to a freshly created node."""
+        params = self._defaults_repo.get_default_params_for_operation(operation)
+        return _json_safe(dict(params)) if isinstance(params, dict) else {}
+
+    def schema_for(self, operation: str) -> list[dict[str, Any]]:
+        """Typed schemas for every hyperparameter of ``operation``.
+
+        Parameters present in the tuner's search space come first (those are the
+        ones evolution actually varies), followed by parameters that only have a
+        default value.
+        """
+        defaults = self.defaults_for(operation)
+        space = self._search_space.get(operation) or self._search_space.get(self._base_name(operation), {})
+
+        schemas: list[dict[str, Any]] = []
+        for name, spec in space.items():
+            if not isinstance(spec, dict):
+                continue
+            schema = _schema_from_search_space(name, spec)
+            if name in defaults:
+                schema["default"] = defaults[name]
+                # A concrete default is a better type hint than the declared type.
+                schema["value_type"] = _value_type(defaults[name], schema["type"], schema.get("choices"))
+            schemas.append(schema)
+
+        covered = {s["name"] for s in schemas}
+        for name, value in defaults.items():
+            if name not in covered:
+                schemas.append(_schema_from_default(name, value))
+
+        return schemas

--- a/backend/fedotweb/catalog/operations.py
+++ b/backend/fedotweb/catalog/operations.py
@@ -1,0 +1,194 @@
+"""The catalogue of operations FEDOT can place into a pipeline.
+
+Everything the UI needs to render an operation palette and to validate a node
+comes from FEDOT's own repositories: which tasks an operation supports, which
+data types it consumes and produces, whether it may sit at the root of a
+pipeline, and -- via :mod:`fedotweb.catalog.hyperparams` -- what its
+hyperparameters look like.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from fedot.core.repository import operation_types_repository as _otr_module
+from fedot.core.repository.operation_types_repository import OperationMetaInfo, OperationTypesRepository
+from fedot.core.repository.tasks import TaskTypesEnum
+
+from .hyperparams import HyperparameterCatalog
+
+#: Repository files, in the order the UI should group them.
+REPOSITORY_KINDS = ("data_operation", "model")
+
+#: Coarse groups used to colour nodes in the pipeline editor.  The first tag that
+#: matches wins, so more specific groups must come first.
+TAG_GROUPS: dict[str, str] = {
+    "data_source": "source",
+    "imputation": "preprocessing",
+    "encoding": "preprocessing",
+    "feature_scaling": "preprocessing",
+    "feature_reduction": "feature_engineering",
+    "feature_selection": "feature_engineering",
+    "feature_engineering": "feature_engineering",
+    "feature_space_transformation": "feature_engineering",
+    "text": "preprocessing",
+    "imbalanced": "preprocessing",
+    "filtering": "preprocessing",
+    "smoothing": "preprocessing",
+    "ts_to_table": "ts_transform",
+    "ts_to_ts": "ts_transform",
+    "decompose": "ts_transform",
+    "ts_model": "ts_model",
+    "boosting": "ensemble",
+    "tree": "tree",
+    "linear": "linear",
+    "non_linear": "non_linear",
+    "deep": "deep",
+}
+
+
+def _enum_name(value: Any) -> str:
+    """Render a FEDOT enum (or anything else) as a short string."""
+    name = getattr(value, "name", None)
+    return name if isinstance(name, str) else str(value)
+
+
+@lru_cache(maxsize=1)
+def _repository_metadata() -> dict[str, dict[str, Any]]:
+    """Descriptions and tags declared in the repository JSON files.
+
+    ``OperationMetaInfo`` does not carry the human-readable ``description``
+    field, so it is read straight from the packaged repository data.
+    """
+    data_dir = Path(_otr_module.__file__).parent / "data"
+    merged: dict[str, dict[str, Any]] = {}
+    for kind in REPOSITORY_KINDS:
+        path = data_dir / f"{kind}_repository.json"
+        if not path.exists():
+            continue
+        content = json.loads(path.read_text(encoding="utf-8"))
+        metadata = content.get("metadata", {})
+        for operation_id, entry in content.get("operations", {}).items():
+            meta_key = entry.get("meta")
+            meta = metadata.get(meta_key, {}) if meta_key else {}
+            merged[operation_id] = {
+                "kind": kind,
+                "family": meta_key,
+                "description": meta.get("description"),
+                "presets": entry.get("presets", []),
+            }
+    return merged
+
+
+def _group_for(tags: list[str], kind: str) -> str:
+    for tag in tags:
+        group = TAG_GROUPS.get(tag)
+        if group:
+            return group
+    return "data_operation" if kind == "data_operation" else "model"
+
+
+class OperationCatalog:
+    """Read-only view over the FEDOT operation repositories."""
+
+    def __init__(self) -> None:
+        # Instantiating the repository is what loads the JSON files; FEDOT caches
+        # them on the class, so repeated construction is cheap.
+        OperationTypesRepository.init_default_repositories()
+        self._repo = OperationTypesRepository(operation_type="all")
+        self._hyperparams = HyperparameterCatalog()
+        self._metadata = _repository_metadata()
+
+    @property
+    def hyperparams(self) -> HyperparameterCatalog:
+        return self._hyperparams
+
+    def _describe(self, info: OperationMetaInfo, *, with_parameters: bool) -> dict[str, Any]:
+        meta = self._metadata.get(info.id, {})
+        tags = list(info.tags or [])
+        kind = meta.get("kind") or "model"
+
+        described: dict[str, Any] = {
+            "id": info.id,
+            "kind": kind,
+            "group": _group_for(tags, kind),
+            "family": meta.get("family"),
+            "description": meta.get("description"),
+            "tags": tags,
+            "presets": list(info.presets or meta.get("presets") or []),
+            "tasks": [_enum_name(t) for t in (info.task_type or [])],
+            "input_types": [_enum_name(t) for t in (info.input_types or [])],
+            "output_types": [_enum_name(t) for t in (info.output_types or [])],
+            "allowed_positions": list(info.allowed_positions or []),
+            "is_default": "non-default" not in tags,
+        }
+        if with_parameters:
+            described["parameters"] = self._hyperparams.schema_for(info.id)
+            described["defaults"] = self._hyperparams.defaults_for(info.id)
+        return described
+
+    def list_operations(
+        self,
+        *,
+        task: str | None = None,
+        kind: str | None = None,
+        include_non_default: bool = True,
+        with_parameters: bool = False,
+    ) -> list[dict[str, Any]]:
+        """All operations, optionally narrowed to a task type and repository kind."""
+        task_type = None
+        if task:
+            try:
+                task_type = TaskTypesEnum(task)
+            except ValueError as exc:
+                raise ValueError(f"Unknown task type: {task}") from exc
+
+        result: list[dict[str, Any]] = []
+        seen = set()
+        for info in self._repo.operations:
+            if info.id in seen:
+                continue
+            if task_type is not None and task_type not in (info.task_type or []):
+                continue
+            described = self._describe(info, with_parameters=with_parameters)
+            if kind and described["kind"] != kind:
+                continue
+            if not include_non_default and not described["is_default"]:
+                continue
+            seen.add(info.id)
+            result.append(described)
+
+        result.sort(key=lambda item: (item["kind"], item["group"], item["id"]))
+        return result
+
+    def get(self, operation_id: str) -> dict[str, Any] | None:
+        """Full description of a single operation, including parameter schemas."""
+        info = self._repo.operation_info_by_id(operation_id)
+        if info is None:
+            return None
+        return self._describe(info, with_parameters=True)
+
+    def exists(self, operation_id: str) -> bool:
+        return self._repo.operation_info_by_id(operation_id) is not None
+
+    def tasks(self) -> list[dict[str, str]]:
+        """Task types FEDOT can solve, with labels for the run-configuration form."""
+        labels = {
+            "classification": "Classification",
+            "regression": "Regression",
+            "ts_forecasting": "Time series forecasting",
+            "clustering": "Clustering",
+        }
+        return [
+            {"id": task.value, "label": labels.get(task.value, task.value.replace("_", " ").title())}
+            for task in TaskTypesEnum
+        ]
+
+
+@lru_cache(maxsize=1)
+def get_catalog() -> OperationCatalog:
+    """Process-wide catalogue instance (building it parses several JSON files)."""
+    return OperationCatalog()

--- a/backend/fedotweb/datasets/preprocessing.py
+++ b/backend/fedotweb/datasets/preprocessing.py
@@ -1,0 +1,278 @@
+"""What FEDOT does to a dataset before a pipeline ever sees it.
+
+A pipeline is only half the story: FEDOT rewrites the input first -- dropping
+columns that are almost entirely empty, dropping columns whose types conflict
+beyond repair, turning numeric columns with few distinct values into categories
+and sparse categorical ones back into numbers. None of that is visible from the
+pipeline graph, and it changes what the model is actually trained on.
+
+This module runs FEDOT's own preprocessor over a dataset and reports what it did,
+column by column, together with the types the pipeline finally receives.
+
+Index bookkeeping matters here. Obligatory preprocessing filters columns in two
+passes, and each pass renumbers what follows: first the gap filter drops columns
+(``ids_relevant_features`` holds the *original* indices of the survivors), then
+the type corrector works on the filtered matrix, so all of its indices are
+positions in that matrix, not in the file. Everything reported below is mapped
+back to file columns, so the report reads against the data the user uploaded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+#: Rows read for the report. The preprocessor's decisions are threshold-based, so
+#: this has to be the whole column to be faithful -- but a guard keeps a huge file
+#: from stalling the request.
+MAX_ROWS_FOR_REPORT = 200_000
+
+
+def _type_name(type_id: Any) -> str:
+    """FEDOT stores column types as ids into a fixed tuple of Python types."""
+    from fedot.preprocessing.data_types import ID_TO_TYPE
+
+    try:
+        python_type = ID_TO_TYPE[int(type_id)]
+    except (KeyError, TypeError, ValueError):
+        return str(type_id)
+    return getattr(python_type, "__name__", str(python_type))
+
+
+def _as_int_list(values: Any) -> list[int]:
+    if values is None:
+        return []
+    try:
+        return [int(value) for value in list(values)]
+    except (TypeError, ValueError):
+        return []
+
+
+def describe_preprocessing(
+    path: Path,
+    *,
+    problem: str,
+    target: str,
+    forecast_length: int = 30,
+) -> dict[str, Any]:
+    """Run FEDOT's preprocessing over a dataset and report what changed."""
+    from fedot.core.data.data import InputData
+    from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
+    from fedot.preprocessing.preprocessing import DataPreprocessor
+
+    task_params = (
+        TsForecastingParams(forecast_length=forecast_length)
+        if problem == "ts_forecasting"
+        else None
+    )
+    task = Task(TaskTypesEnum(problem), task_params)
+
+    if problem == "ts_forecasting":
+        data = InputData.from_csv_time_series(file_path=path, task=task, target_column=target)
+    else:
+        data = InputData.from_csv(file_path=path, task=task, target_columns=target)
+
+    rows_before = int(len(data.idx))
+    if rows_before > MAX_ROWS_FOR_REPORT:
+        raise ValueError(
+            f"This dataset has {rows_before} rows; the preprocessing report is limited to "
+            f"{MAX_ROWS_FOR_REPORT}"
+        )
+
+    features_shape = getattr(data.features, "shape", (rows_before, 0))
+    columns_before = int(features_shape[1]) if len(features_shape) > 1 else 1
+
+    preprocessor = DataPreprocessor()
+    prepared = preprocessor.obligatory_prepare_for_fit(data)
+
+    corrector = getattr(preprocessor, "types_correctors", None)
+    # The corrector is kept per data source; a single table has one.
+    if isinstance(corrector, dict):
+        corrector = next(iter(corrector.values()), None)
+
+    # ---------------------------------------------------------- column mapping
+
+    relevant = getattr(preprocessor, "ids_relevant_features", None)
+    kept_after_gaps = _as_int_list(next(iter(relevant.values()), None)) if isinstance(relevant, dict) else []
+    if not kept_after_gaps:
+        # An empty id list means FEDOT skipped the filter and kept everything.
+        kept_after_gaps = list(range(columns_before))
+    dropped_for_gaps = sorted(set(range(columns_before)) - set(kept_after_gaps))
+
+    def to_file_column(position: int) -> int:
+        """Corrector position -> index of the column in the uploaded file."""
+        return kept_after_gaps[position] if position < len(kept_after_gaps) else position
+
+    conflict_positions = _as_int_list(getattr(corrector, "columns_to_del", None)) if corrector else []
+    dropped_for_conflicts = sorted(to_file_column(p) for p in conflict_positions)
+
+    #: File columns still present in the matrix the pipeline receives, in order.
+    surviving = [
+        kept_after_gaps[position]
+        for position in range(len(kept_after_gaps))
+        if position not in set(conflict_positions)
+    ]
+
+    # ------------------------------------------------------------- final types
+
+    col_type_ids = getattr(getattr(prepared, "supplementary_data", None), "col_type_ids", None)
+    raw_final = []
+    if isinstance(col_type_ids, dict) and col_type_ids.get("features") is not None:
+        raw_final = list(col_type_ids["features"])
+
+    #: One entry per file column; ``None`` where the column did not survive.
+    final_types: list[str | None] = [None] * columns_before
+    for position, file_column in enumerate(surviving):
+        if position < len(raw_final) and file_column < columns_before:
+            final_types[file_column] = _type_name(raw_final[position])
+
+    features_after = getattr(prepared.features, "shape", (0, 0))
+    rows_after = int(features_after[0]) if features_after else 0
+    columns_after = int(features_after[1]) if len(features_after) > 1 else 1
+
+    # ------------------------------------------------------------ target type
+
+    target_type = None
+    target_type_ids = getattr(corrector, "target_type_ids", None) if corrector else None
+    target_ids_list = _as_int_list(target_type_ids)
+    if target_ids_list:
+        target_type = _type_name(target_ids_list[0])
+
+    return {
+        "problem": problem,
+        "target": target,
+        "rows": {"before": rows_before, "after": rows_after},
+        "columns": {"before": columns_before, "after": columns_after},
+        "source_types": _summarise_source_types(
+            corrector, columns_before, to_file_column, dropped_for_gaps
+        ),
+        "final_types": final_types,
+        "target_type": target_type,
+        "steps": _describe_steps(
+            preprocessor, corrector, to_file_column, dropped_for_gaps, dropped_for_conflicts
+        ),
+        "note": (
+            "This is FEDOT's obligatory preprocessing — the part applied to every run, "
+            "before any pipeline. Encoding and imputation that belong to the pipeline "
+            "itself appear as nodes in the pipeline graph instead."
+        ),
+    }
+
+
+def _summarise_source_types(
+    corrector: Any,
+    columns_before: int,
+    to_file_column,
+    dropped_for_gaps: list[int],
+) -> list[dict[str, Any]]:
+    """Per-column counts of what the raw file actually held, in file order.
+
+    ``features_columns_info`` is a frame indexed by the facts the corrector
+    gathered -- how many ints, floats, strings and gaps each column had. That is
+    exactly what its decisions were made from, so it belongs in the report.
+    Columns the gap filter removed never reach the corrector, so their rows only
+    say that much.
+    """
+    rows: dict[int, dict[str, Any]] = {index: {"column": index} for index in range(columns_before)}
+    for index in dropped_for_gaps:
+        rows[index]["types"] = []
+        rows[index]["dropped_for_gaps"] = True
+
+    info = getattr(corrector, "features_columns_info", None) if corrector else None
+    if info is not None and not getattr(info, "empty", True):
+        for position in info.columns:
+            entry = rows.get(to_file_column(int(position)))
+            if entry is None:
+                continue
+            for field in info.index:
+                value = info.loc[field, position]
+                if field == "nan_ids":
+                    # The positions themselves are noise; the count is the fact.
+                    entry["nan_number"] = 0 if value is None else int(len(value))
+                    continue
+                if field == "types":
+                    # These arrive as numpy arrays, whose truthiness is ambiguous,
+                    # so the emptiness check has to be explicit.
+                    found = [] if value is None else list(value)
+                    entry["types"] = sorted({_type_name(t) for t in found})
+                    continue
+                try:
+                    entry[str(field)] = int(value)
+                except (TypeError, ValueError):
+                    entry[str(field)] = str(value)
+
+    return [rows[index] for index in range(columns_before)]
+
+
+def _describe_steps(
+    preprocessor: Any,
+    corrector: Any,
+    to_file_column,
+    dropped_for_gaps: list[int],
+    dropped_for_conflicts: list[int],
+) -> list[dict[str, Any]]:
+    """The decisions the preprocessor made, in the order it makes them."""
+
+    def step(step_id: str, title: str, detail: str, columns: list[int]) -> dict[str, Any]:
+        return {
+            "id": step_id,
+            "title": title,
+            "detail": detail,
+            "columns": sorted(columns),
+            "applied": bool(columns),
+        }
+
+    def mapped(attribute: str) -> list[int]:
+        positions = _as_int_list(getattr(corrector, attribute, None)) if corrector else []
+        return [to_file_column(position) for position in positions]
+
+    failed = getattr(corrector, "string_columns_transformation_failed", None) if corrector else None
+    failed_columns = [to_file_column(int(position)) for position in (failed or {})]
+
+    steps = [
+        step(
+            "empty_columns",
+            "Columns dropped as almost entirely empty",
+            "A column that is more than 90% gaps has nothing to learn from, so FEDOT removes it.",
+            dropped_for_gaps,
+        ),
+        step(
+            "type_conflicts",
+            "Columns dropped for irreconcilable types",
+            "A column holding roughly as many genuine strings as numbers cannot be "
+            "converted either way, so FEDOT removes it.",
+            dropped_for_conflicts,
+        ),
+        step(
+            "numeric_to_categorical",
+            "Numeric columns treated as categories",
+            "Fewer distinct values than FEDOT's threshold, so the numbers are labels.",
+            mapped("numerical_into_str"),
+        ),
+        step(
+            "categorical_to_numeric",
+            "Categorical columns converted to numbers",
+            "Enough distinct numeric-looking values that a numeric column is a better fit.",
+            mapped("categorical_into_float"),
+        ),
+        step(
+            "conversion_failed",
+            "Columns kept as text after a failed numeric conversion",
+            "Some cells could not be parsed as numbers, so the column stays categorical.",
+            failed_columns,
+        ),
+    ]
+
+    encoders = getattr(preprocessor, "features_encoders", None)
+    if isinstance(encoders, dict) and encoders:
+        steps.append(
+            {
+                "id": "encoding",
+                "title": "Categorical encoding",
+                "detail": ", ".join(type(encoder).__name__ for encoder in encoders.values()),
+                "columns": [],
+                "applied": True,
+            }
+        )
+
+    return steps

--- a/backend/fedotweb/datasets/service.py
+++ b/backend/fedotweb/datasets/service.py
@@ -1,0 +1,137 @@
+"""Dataset intake: upload, inspection and preview.
+
+The legacy GUI could only work with three datasets baked into the repository and
+seeded into MongoDB.  Here a user can upload their own CSV, see what is in it and
+pick a target column before configuring a run.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import shutil
+from pathlib import Path
+from typing import Any
+
+#: Rows read to infer column types and to build the preview.
+INSPECTION_ROWS = 500
+
+#: Delimiters tried when sniffing a CSV.
+CANDIDATE_DELIMITERS = ",;\t|"
+
+
+class DatasetError(ValueError):
+    """Raised when an uploaded file cannot be used as a dataset."""
+
+
+def _sniff_delimiter(sample: str) -> str:
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=CANDIDATE_DELIMITERS)
+        return dialect.delimiter
+    except csv.Error:
+        # Fall back to whichever candidate appears most often in the header line.
+        header = sample.splitlines()[0] if sample else ""
+        counts = {d: header.count(d) for d in CANDIDATE_DELIMITERS}
+        best = max(counts, key=counts.get)
+        return best if counts[best] else ","
+
+
+def _looks_numeric(value: str) -> bool:
+    if value == "":
+        return False
+    try:
+        number = float(value)
+    except ValueError:
+        return False
+    return not math.isnan(number)
+
+
+def _infer_column_type(values: list[str]) -> str:
+    non_empty = [v for v in values if v not in ("", "nan", "NaN", "NA", "null", "None")]
+    if not non_empty:
+        return "empty"
+    if all(_looks_numeric(v) for v in non_empty):
+        # A small number of distinct integers reads better as a category.
+        distinct = set(non_empty)
+        if len(distinct) <= 10 and all(float(v).is_integer() for v in distinct):
+            return "categorical_numeric"
+        return "numeric"
+    return "categorical"
+
+
+def inspect_csv(path: Path) -> dict[str, Any]:
+    """Read the head of a CSV and describe its columns."""
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise DatasetError(f"Cannot read the uploaded file: {exc}") from exc
+
+    if not raw.strip():
+        raise DatasetError("The uploaded file is empty")
+
+    delimiter = _sniff_delimiter(raw[:8192])
+    reader = csv.reader(raw.splitlines(), delimiter=delimiter)
+
+    try:
+        header = next(reader)
+    except StopIteration as exc:
+        raise DatasetError("The uploaded file has no header row") from exc
+
+    header = [name.strip() or f"column_{i}" for i, name in enumerate(header)]
+    if len(header) < 2:
+        raise DatasetError(
+            "At least two columns are required: one or more features and a target"
+        )
+
+    sample_rows: list[list[str]] = []
+    total_rows = 0
+    for row in reader:
+        total_rows += 1
+        if len(sample_rows) < INSPECTION_ROWS:
+            # Pad or trim ragged rows so the preview stays rectangular.
+            normalised = (row + [""] * len(header))[: len(header)]
+            sample_rows.append(normalised)
+
+    columns: list[dict[str, Any]] = []
+    for index, name in enumerate(header):
+        values = [row[index] for row in sample_rows]
+        non_empty = [v for v in values if v != ""]
+        columns.append(
+            {
+                "name": name,
+                "index": index,
+                "type": _infer_column_type(values),
+                "distinct_sample": len(set(non_empty)),
+                "missing_sample": len(values) - len(non_empty),
+                "examples": non_empty[:3],
+            }
+        )
+
+    return {
+        "delimiter": delimiter,
+        "columns": columns,
+        "n_rows": total_rows,
+        "n_columns": len(header),
+        # Ragged rows were padded to the header width above, so the lengths match.
+        "preview": [dict(zip(header, row, strict=True)) for row in sample_rows[:20]],
+    }
+
+
+def suggest_target(columns: list[dict[str, Any]]) -> str | None:
+    """Guess the target column, preferring FEDOT's own convention."""
+    names = {column["name"].lower(): column["name"] for column in columns}
+    for candidate in ("target", "label", "class", "y"):
+        if candidate in names:
+            return names[candidate]
+    return columns[-1]["name"] if columns else None
+
+
+def store_upload(source: Path, destination_dir: Path, filename: str) -> Path:
+    """Move an uploaded file into the workspace under a safe name."""
+    safe_name = Path(filename).name.replace("\\", "_").replace("/", "_")
+    if not safe_name:
+        raise DatasetError("The uploaded file has no usable name")
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    destination = destination_dir / safe_name
+    shutil.move(str(source), destination)
+    return destination

--- a/backend/fedotweb/history/__init__.py
+++ b/backend/fedotweb/history/__init__.py
@@ -1,0 +1,26 @@
+"""The evolution history: genealogy graphs, from a saved run or a running one."""
+
+from .lineage import history_to_lineage
+from .live import individual_pipeline_from_events, lineage_from_events
+from .model import build_lineage
+from .service import (
+    HistoryUnavailable,
+    individual_pipeline,
+    lineage_graph,
+    live_individual_pipeline,
+    live_lineage_graph,
+    load_history,
+)
+
+__all__ = [
+    "HistoryUnavailable",
+    "build_lineage",
+    "history_to_lineage",
+    "individual_pipeline",
+    "individual_pipeline_from_events",
+    "lineage_from_events",
+    "lineage_graph",
+    "live_individual_pipeline",
+    "live_lineage_graph",
+    "load_history",
+]

--- a/backend/fedotweb/history/lineage.py
+++ b/backend/fedotweb/history/lineage.py
@@ -1,0 +1,141 @@
+"""The evolution history as a graph, from a finished run's ``OptHistory``.
+
+A fitness curve says *that* the population improved; it does not say *how*. This
+module turns a GOLEM ``OptHistory`` into a genealogy: which pipeline was crossed
+with which, what mutated into what, and which of those lines actually led to the
+pipeline that won.
+
+The graph is bipartite by layer:
+
+* even layers hold **individuals** -- one pipeline evaluated in one generation
+* odd layers hold **operators** -- the mutation or crossover that produced the
+  individuals in the next generation
+
+An individual that survives selection unchanged is linked straight to its copy in
+the following generation, so a surviving line reads as an unbroken vertical run.
+
+The same graph is assembled from live progress events by :mod:`fedotweb.history.live`;
+both go through :func:`fedotweb.history.model.build_lineage`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from golem.core.optimisers.opt_history_objects.individual import Individual
+from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
+
+from .model import (
+    DEFAULT_MAX_INDIVIDUALS,
+    LineageGeneration,
+    LineageIndividual,
+    LineageOperator,
+    build_lineage,
+)
+
+
+def fitness_value(individual: Individual) -> float | None:
+    """Fitness as a plain comparable number, or ``None`` when it never evaluated."""
+    fitness = getattr(individual, "fitness", None)
+    value = getattr(fitness, "value", None)
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    # NaN and infinities mean the evaluation failed.
+    return number if number == number and abs(number) != float("inf") else None
+
+
+def operations_of(individual: Individual) -> list[str]:
+    """Operation names in the individual's graph, for a compact node label."""
+    graph = getattr(individual, "graph", None)
+    nodes = getattr(graph, "nodes", None) or []
+    names = []
+    for node in nodes:
+        name = getattr(node, "name", None) or getattr(node, "content", {}).get("name")
+        names.append(str(name))
+    return names
+
+
+def operator_label(operator: Any) -> str:
+    names = [str(name) for name in (getattr(operator, "operators", None) or [])]
+    return ", ".join(names) if names else str(getattr(operator, "type_", "operator"))
+
+
+def _operators_of(individual: Individual) -> list[LineageOperator]:
+    try:
+        operators = list(individual.operators_from_prev_generation)
+    except ValueError:
+        # GOLEM raises when inheritance data is inconsistent; a broken lineage
+        # should not cost the whole graph.
+        return []
+
+    return [
+        LineageOperator(
+            uid=str(operator.uid),
+            type_=str(operator.type_),
+            label=operator_label(operator),
+            parent_uids=[str(parent.uid) for parent in (operator.parent_individuals or ())],
+        )
+        for operator in operators
+    ]
+
+
+def normalise_history(history: OptHistory) -> list[LineageGeneration]:
+    """Turn a saved ``OptHistory`` into the builder's input."""
+    generations: list[LineageGeneration] = []
+    for index, population in enumerate(history.generations or []):
+        individuals = [
+            LineageIndividual(
+                uid=str(individual.uid),
+                fitness=fitness_value(individual),
+                operations=operations_of(individual),
+                native_generation=individual.native_generation,
+                operators=_operators_of(individual) if individual.native_generation == index else [],
+            )
+            for individual in population
+        ]
+        generations.append(
+            LineageGeneration(
+                index=index,
+                raw_label=str(getattr(population, "label", None) or ""),
+                individuals=individuals,
+            )
+        )
+    return generations
+
+
+def _final_uids(history: OptHistory) -> set[str]:
+    finals = list(history.final_choices or [])
+    if not finals:
+        archive = history.archive_history or []
+        if archive:
+            evaluated = [ind for ind in archive[-1] if fitness_value(ind) is not None]
+            if evaluated:
+                finals = [min(evaluated, key=fitness_value)]
+    return {str(individual.uid) for individual in finals}
+
+
+def history_to_lineage(
+    history: OptHistory,
+    *,
+    only_winning_path: bool = True,
+    max_individuals: int = DEFAULT_MAX_INDIVIDUALS,
+) -> dict[str, Any]:
+    """Build the genealogy graph for a completed optimisation.
+
+    Args:
+        history: the history saved by the run worker.
+        only_winning_path: keep just the individuals that led to the final
+            choice. A full population graph is available but grows as
+            ``pop_size x generations``.
+        max_individuals: safety ceiling on the payload size.
+    """
+    return build_lineage(
+        normalise_history(history),
+        final_uids=_final_uids(history),
+        only_winning_path=only_winning_path,
+        max_individuals=max_individuals,
+    )

--- a/backend/fedotweb/history/live.py
+++ b/backend/fedotweb/history/live.py
@@ -1,0 +1,221 @@
+"""The genealogy of a run that is still going.
+
+The saved ``OptHistory`` only exists once FEDOT finishes, so a run in progress
+has no history file to read. What it does have is the stream of ``population``
+events the worker emits from GOLEM's iteration callback -- one per generation,
+carrying the same ancestry facts.
+
+Those events are replayed here into the normalised form
+:mod:`fedotweb.history.model` builds from, so the genealogy shown during a run
+and the one shown afterwards are the same drawing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .model import (
+    DEFAULT_MAX_INDIVIDUALS,
+    LineageGeneration,
+    LineageIndividual,
+    LineageOperator,
+    build_lineage,
+)
+
+
+def _coerce_fitness(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number == number and abs(number) != float("inf") else None
+
+
+def _individual_from_payload(payload: dict[str, Any]) -> LineageIndividual:
+    operators = [
+        LineageOperator(
+            uid=str(operator.get("uid", "")),
+            type_=str(operator.get("type", "operator")),
+            label=str(operator.get("label", "")),
+            parent_uids=[str(uid) for uid in (operator.get("parents") or [])],
+        )
+        for operator in (payload.get("operators") or [])
+    ]
+    return LineageIndividual(
+        uid=str(payload.get("uid", "")),
+        fitness=_coerce_fitness(payload.get("fitness")),
+        operations=[str(name) for name in (payload.get("operations") or [])],
+        # Carried through for display only; the builder decides what is new from
+        # where an individual first appears, not from this counter.
+        native_generation=payload.get("native_generation"),
+        operators=operators,
+    )
+
+
+def individual_pipeline_from_events(
+    events: list[dict[str, Any]], individual_uid: str
+) -> dict[str, Any] | None:
+    """The pipeline of one individual, from the live event stream.
+
+    The worker sends bare structure -- operations, wiring and chosen parameters --
+    so what comes back here is enriched with the catalogue metadata the editor
+    canvas expects, rather than round-tripped through FEDOT.
+    """
+    from ..catalog import get_catalog
+
+    latest: dict[str, Any] | None = None
+    generation: int | None = None
+    for event in events:
+        if event.get("kind") != "population":
+            continue
+        payload = event.get("payload") or {}
+        for entry in payload.get("individuals") or []:
+            if str(entry.get("uid")) == individual_uid and entry.get("graph"):
+                latest = entry
+                generation = payload.get("generation")
+
+    if latest is None:
+        return None
+
+    catalog = get_catalog()
+    raw = latest["graph"]
+    nodes = []
+    parents: dict[str, list[str]] = {node["id"]: [] for node in raw["nodes"]}
+    children: dict[str, list[str]] = {node["id"]: [] for node in raw["nodes"]}
+    for edge in raw.get("edges") or []:
+        parents.setdefault(edge["target"], []).append(edge["source"])
+        children.setdefault(edge["source"], []).append(edge["target"])
+
+    for node in raw["nodes"]:
+        described = catalog.get(node["operation"]) or {}
+        nodes.append(
+            {
+                "id": node["id"],
+                "operation": node["operation"],
+                "label": node["operation"],
+                "kind": described.get("kind", "model"),
+                "group": described.get("group", "model"),
+                "description": described.get("description"),
+                "tags": described.get("tags", []),
+                "params": node.get("params") or {},
+                "defaults": described.get("defaults", {}),
+                "parents": parents.get(node["id"], []),
+                "children": children.get(node["id"], []),
+                "is_primary": not parents.get(node["id"]),
+                "is_root": not children.get(node["id"]),
+            }
+        )
+
+    edges = [
+        {"id": f"{edge['source']}->{edge['target']}", "source": edge["source"], "target": edge["target"]}
+        for edge in (raw.get("edges") or [])
+    ]
+
+    return {
+        "uid": individual_uid,
+        "nodes": nodes,
+        "edges": edges,
+        "length": len(nodes),
+        "depth": _depth_of(parents),
+        "fitness": _coerce_fitness(latest.get("fitness")),
+        "generation": generation,
+    }
+
+
+def _depth_of(parents: dict[str, list[str]]) -> int:
+    """Longest chain from a primary node to a sink."""
+    memo: dict[str, int] = {}
+
+    def depth(node_id: str, seen: frozenset[str]) -> int:
+        if node_id in memo:
+            return memo[node_id]
+        if node_id in seen:  # defensive: a cycle should not hang the request
+            return 0
+        chain = [depth(parent, seen | {node_id}) for parent in parents.get(node_id, [])]
+        result = 1 + max(chain, default=0)
+        memo[node_id] = result
+        return result
+
+    return max((depth(node_id, frozenset()) for node_id in parents), default=0)
+
+
+def normalise_events(events: list[dict[str, Any]]) -> tuple[list[LineageGeneration], set[str]]:
+    """Replay stored ``population`` events into generations and the current best.
+
+    The worker numbers generations from one, matching GOLEM's own counter; the
+    graph indexes them from zero, so the offset is removed here. A generation
+    reported more than once -- which a reconnect or a replay can cause -- keeps
+    only its latest payload.
+    """
+    raw: dict[int, list[dict[str, Any]]] = {}
+    best_uids: set[str] = set()
+
+    for event in events:
+        if event.get("kind") != "population":
+            continue
+        payload = event.get("payload") or {}
+        try:
+            generation = int(payload.get("generation", 0))
+        except (TypeError, ValueError):
+            continue
+
+        raw[generation] = list(payload.get("individuals") or [])
+        reported_best = payload.get("best_uids") or []
+        if reported_best:
+            best_uids = {str(uid) for uid in reported_best}
+
+    if not raw:
+        return [], set()
+
+    ordered = sorted(raw)
+    offset = ordered[0]
+    generations = [
+        LineageGeneration(
+            index=generation - offset,
+            # A live run has no labelled seed or result populations; every event
+            # is a real generation.
+            raw_label="",
+            individuals=[_individual_from_payload(entry) for entry in raw[generation]],
+        )
+        for generation in ordered
+    ]
+    return generations, best_uids
+
+
+def lineage_from_events(
+    events: list[dict[str, Any]],
+    *,
+    only_winning_path: bool = True,
+    max_individuals: int = DEFAULT_MAX_INDIVIDUALS,
+) -> dict[str, Any] | None:
+    """Genealogy of a run in progress, or ``None`` when nothing was reported yet."""
+    generations, best_uids = normalise_events(events)
+    if not generations:
+        return None
+
+    if not best_uids:
+        # Before the archive reports anything, treat the best-scoring individual
+        # seen so far as the tip of the lineage.
+        scored = [
+            individual
+            for generation in generations
+            for individual in generation.individuals
+            if individual.fitness is not None
+        ]
+        if scored:
+            best_uids = {min(scored, key=lambda individual: individual.fitness).uid}
+
+    graph = build_lineage(
+        generations,
+        final_uids=best_uids,
+        only_winning_path=only_winning_path,
+        max_individuals=max_individuals,
+    )
+    # Nothing is final while the run is going; the marker means "best so far".
+    for node in graph["nodes"]:
+        if node["kind"] == "individual" and node.get("is_final_choice"):
+            node["is_current_best"] = True
+            node["is_final_choice"] = False
+    return graph

--- a/backend/fedotweb/history/model.py
+++ b/backend/fedotweb/history/model.py
@@ -1,0 +1,297 @@
+"""The shape a genealogy is built from, and the builder itself.
+
+A run's ancestry can come from two places: the ``OptHistory`` saved when the run
+finishes, or the population events the worker streams while it is still going.
+Both are normalised into the structures here so a single builder produces the
+graph -- a live genealogy and a finished one are then the same drawing, not two
+implementations that drift apart.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Selection is bookkeeping rather than a transformation, so it is not drawn.
+HIDDEN_OPERATOR_TYPES = frozenset({"selection"})
+
+#: Ceiling on how many individuals to describe, so a long run cannot produce a
+#: payload the browser chokes on.
+DEFAULT_MAX_INDIVIDUALS = 1500
+
+#: GOLEM stores the seed populations and the result alongside the real
+#: generations, so a run of seven generations reports ten. Labelling them keeps
+#: the graph honest about how much evolution actually happened.
+GENERATION_LABELS = {
+    "initial_assumptions": "initial assumptions",
+    "extended_initial_assumptions": "extended assumptions",
+    "final_choices": "final choice",
+}
+
+
+@dataclass(frozen=True)
+class LineageOperator:
+    """A mutation or crossover that produced an individual."""
+
+    uid: str
+    type_: str
+    label: str
+    parent_uids: list[str]
+
+
+@dataclass(frozen=True)
+class LineageIndividual:
+    """One pipeline as recorded in one generation."""
+
+    uid: str
+    fitness: float | None
+    operations: list[str]
+    native_generation: int | None
+    #: Only meaningful for the generation that created this individual.
+    operators: list[LineageOperator] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class LineageGeneration:
+    """One stored population, which may be evolution or bookkeeping."""
+
+    index: int
+    raw_label: str
+    individuals: list[LineageIndividual]
+
+
+def generation_metadata(generations: list[LineageGeneration]) -> list[dict[str, Any]]:
+    """Describe each stored generation, separating evolution from bookkeeping."""
+    metadata: list[dict[str, Any]] = []
+    evolutionary_index = 0
+
+    for generation in generations:
+        is_evolutionary = generation.raw_label not in GENERATION_LABELS
+        if is_evolutionary:
+            evolutionary_index += 1
+            label = f"gen {evolutionary_index}"
+        else:
+            label = GENERATION_LABELS[generation.raw_label]
+
+        metadata.append(
+            {
+                "index": generation.index,
+                "label": label,
+                "raw_label": generation.raw_label,
+                "size": len(generation.individuals),
+                "is_evolutionary": is_evolutionary,
+            }
+        )
+    return metadata
+
+
+class LineageBuilder:
+    """Assembles the genealogy graph from normalised generations."""
+
+    def __init__(
+        self,
+        generations: list[LineageGeneration],
+        *,
+        final_uids: set[str],
+        max_individuals: int = DEFAULT_MAX_INDIVIDUALS,
+    ) -> None:
+        self._generations = generations
+        self._final_uids = final_uids
+        self._max_individuals = max_individuals
+        self._nodes: list[dict[str, Any]] = []
+        self._edges: list[dict[str, str]] = []
+        #: (generation, individual uid) -> node id, so an individual that appears
+        #: in several generations is a distinct node in each of them.
+        self._individual_nodes: dict[tuple[int, str], str] = {}
+        self._edge_ids: set[str] = set()
+        self._truncated = False
+
+    # ------------------------------------------------------------------ helpers
+
+    def _add_edge(self, source: str, target: str, kind: str) -> None:
+        if source == target:
+            return
+        edge_id = f"{source}->{target}"
+        if edge_id in self._edge_ids:
+            return
+        self._edge_ids.add(edge_id)
+        self._edges.append({"id": edge_id, "source": source, "target": target, "kind": kind})
+
+    def _latest_node_before(self, uid: str, generation: int) -> str | None:
+        """The most recent node for ``uid`` in a generation earlier than ``generation``.
+
+        An individual can drop out of one population and come back in a later one
+        -- elitism reintroduces archived graphs -- and a parent is not always
+        recorded in the generation immediately before its child. Looking only one
+        step back leaves those nodes with no incoming edge, which reads as a
+        pipeline that appeared from nowhere.
+        """
+        for candidate in range(generation - 1, -1, -1):
+            node_id = self._individual_nodes.get((candidate, uid))
+            if node_id is not None:
+                return node_id
+        return None
+
+    # ----------------------------------------------------------------- ancestry
+
+    def _winning_uids(self) -> set[str]:
+        """Every individual on a line of descent leading to the current best.
+
+        Without this the graph shows every pipeline ever evaluated, which for a
+        realistic run is thousands of nodes and no story.
+        """
+        parents_of: dict[str, set[str]] = {}
+        for generation in self._generations:
+            for individual in generation.individuals:
+                known = parents_of.setdefault(individual.uid, set())
+                for operator in individual.operators:
+                    known.update(operator.parent_uids)
+
+        winning: set[str] = set()
+        frontier = list(self._final_uids)
+        # Ancestry is a DAG; a visited set keeps a diamond from being walked twice.
+        while frontier:
+            uid = frontier.pop()
+            if uid in winning:
+                continue
+            winning.add(uid)
+            frontier.extend(parents_of.get(uid, ()))
+        return winning
+
+    # -------------------------------------------------------------------- build
+
+    def build(self, *, only_winning_path: bool) -> dict[str, Any]:
+        winning = self._winning_uids()
+        described = 0
+
+        for generation in self._generations:
+            best_value: float | None = None
+            best_node_id: str | None = None
+
+            for position, individual in enumerate(generation.individuals):
+                if only_winning_path and individual.uid not in winning:
+                    continue
+                if described >= self._max_individuals:
+                    self._truncated = True
+                    break
+
+                node_id = f"ind:{generation.index}:{individual.uid}"
+                self._nodes.append(
+                    {
+                        "id": node_id,
+                        "kind": "individual",
+                        "uid": individual.uid,
+                        "generation": generation.index,
+                        "index": position,
+                        "layer": generation.index * 2,
+                        "fitness": individual.fitness,
+                        "operations": individual.operations,
+                        "length": len(individual.operations),
+                        "native_generation": individual.native_generation,
+                        "is_best_in_generation": False,
+                        "is_final_choice": individual.uid in self._final_uids,
+                        "on_winning_path": individual.uid in winning,
+                    }
+                )
+                self._individual_nodes[(generation.index, individual.uid)] = node_id
+                described += 1
+
+                if individual.fitness is not None and (
+                    best_value is None or individual.fitness < best_value
+                ):
+                    best_value, best_node_id = individual.fitness, node_id
+
+                # An individual carried over unchanged keeps its uid, so linking
+                # the two copies shows survival as a continuous line.
+                previous = self._latest_node_before(individual.uid, generation.index)
+                if previous is not None:
+                    self._add_edge(previous, node_id, "survival")
+
+            if best_node_id is not None:
+                next(n for n in self._nodes if n["id"] == best_node_id)["is_best_in_generation"] = True
+
+        self._link_operators(winning, only_winning_path)
+
+        metadata = generation_metadata(self._generations)
+        return {
+            "nodes": self._nodes,
+            "edges": self._edges,
+            "generations": len(self._generations),
+            "evolution_generations": sum(1 for entry in metadata if entry["is_evolutionary"]),
+            "generation_meta": metadata,
+            "truncated": self._truncated,
+        }
+
+    def _link_operators(self, winning: set[str], only_winning_path: bool) -> None:
+        """Insert the mutation/crossover nodes between consecutive generations."""
+        seen_operators: dict[tuple[int, str], str] = {}
+
+        for generation in self._generations:
+            if generation.index == 0:
+                continue
+
+            for individual in generation.individuals:
+                if only_winning_path and individual.uid not in winning:
+                    continue
+                child_node_id = self._individual_nodes.get((generation.index, individual.uid))
+                if child_node_id is None:
+                    continue
+                # Only the generation that first shows an individual draws the
+                # operators that made it; later copies are survivors and are
+                # linked as such. First appearance is used rather than
+                # `native_generation` because the two sources number generations
+                # differently -- GOLEM's live counter starts at one, the value
+                # stored on an individual starts at zero -- and comparing the
+                # wrong pair silently drops every operator.
+                if self._latest_node_before(individual.uid, generation.index) is not None:
+                    continue
+
+                previous_node_id: str | None = None
+                for operator in individual.operators:
+                    if operator.type_ in HIDDEN_OPERATOR_TYPES or not operator.parent_uids:
+                        continue
+
+                    key = (generation.index, operator.uid)
+                    operator_node_id = seen_operators.get(key)
+                    if operator_node_id is None:
+                        operator_node_id = f"op:{generation.index}:{operator.uid}"
+                        seen_operators[key] = operator_node_id
+                        self._nodes.append(
+                            {
+                                "id": operator_node_id,
+                                "kind": "operator",
+                                "uid": operator.uid,
+                                "generation": generation.index,
+                                "layer": generation.index * 2 - 1,
+                                "operator_type": operator.type_,
+                                "label": operator.label,
+                                "on_winning_path": individual.uid in winning,
+                            }
+                        )
+
+                    if previous_node_id is not None:
+                        # Operators applied in sequence, e.g. crossover then mutation.
+                        self._add_edge(previous_node_id, operator_node_id, "chain")
+                    else:
+                        for parent_uid in operator.parent_uids:
+                            parent_node_id = self._latest_node_before(parent_uid, generation.index)
+                            if parent_node_id is not None:
+                                self._add_edge(parent_node_id, operator_node_id, operator.type_)
+
+                    previous_node_id = operator_node_id
+
+                if previous_node_id is not None:
+                    self._add_edge(previous_node_id, child_node_id, "produces")
+
+
+def build_lineage(
+    generations: list[LineageGeneration],
+    *,
+    final_uids: set[str],
+    only_winning_path: bool = True,
+    max_individuals: int = DEFAULT_MAX_INDIVIDUALS,
+) -> dict[str, Any]:
+    """Build the genealogy graph from normalised generations."""
+    return LineageBuilder(
+        generations, final_uids=final_uids, max_individuals=max_individuals
+    ).build(only_winning_path=only_winning_path)

--- a/backend/fedotweb/history/model.py
+++ b/backend/fedotweb/history/model.py
@@ -9,7 +9,7 @@ implementations that drift apart.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 #: Selection is bookkeeping rather than a transformation, so it is not drawn.
@@ -284,6 +284,41 @@ class LineageBuilder:
                     self._add_edge(previous_node_id, child_node_id, "produces")
 
 
+def _without_plateau_tail(
+    generations: list[LineageGeneration],
+) -> tuple[list[LineageGeneration], int]:
+    """Drop the evolutionary generations after the best fitness last improved.
+
+    In the winning-path view those generations only repeat the same leader as a
+    chain of survival edges, which reads as content while saying nothing. The
+    bookkeeping generations (seeds and the final choice) always stay, and the
+    kept generations are re-indexed to stay contiguous because the layout draws
+    a placeholder row for every missing generation number.
+    """
+    best: float | None = None
+    last_improvement: int | None = None
+    for generation in generations:
+        values = [ind.fitness for ind in generation.individuals if ind.fitness is not None]
+        if not values:
+            continue
+        generation_best = min(values)
+        if best is None or generation_best < best:
+            best = generation_best
+            if generation.raw_label not in GENERATION_LABELS:
+                last_improvement = generation.index
+
+    kept = [
+        generation
+        for generation in generations
+        if generation.raw_label in GENERATION_LABELS
+        or (last_improvement is not None and generation.index <= last_improvement)
+    ]
+    hidden = len(generations) - len(kept)
+    if hidden == 0:
+        return generations, 0
+    return [replace(generation, index=index) for index, generation in enumerate(kept)], hidden
+
+
 def build_lineage(
     generations: list[LineageGeneration],
     *,
@@ -292,6 +327,11 @@ def build_lineage(
     max_individuals: int = DEFAULT_MAX_INDIVIDUALS,
 ) -> dict[str, Any]:
     """Build the genealogy graph from normalised generations."""
-    return LineageBuilder(
+    hidden_plateau = 0
+    if only_winning_path:
+        generations, hidden_plateau = _without_plateau_tail(generations)
+    payload = LineageBuilder(
         generations, final_uids=final_uids, max_individuals=max_individuals
     ).build(only_winning_path=only_winning_path)
+    payload["hidden_plateau_generations"] = hidden_plateau
+    return payload

--- a/backend/fedotweb/history/service.py
+++ b/backend/fedotweb/history/service.py
@@ -1,0 +1,124 @@
+"""Loading saved optimisation histories and answering questions about them."""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
+
+from .lineage import history_to_lineage
+from .live import individual_pipeline_from_events, lineage_from_events
+
+#: Deserialising a history costs seconds for a long run, and every click on the
+#: lineage graph needs the same object, so a few are kept in memory.
+_CACHE_SIZE = 4
+
+
+class HistoryUnavailable(FileNotFoundError):
+    """Raised when a run has no saved history."""
+
+
+class _HistoryCache:
+    """Small LRU of parsed histories, keyed by file path and modification time."""
+
+    def __init__(self, size: int = _CACHE_SIZE) -> None:
+        self._entries: OrderedDict[tuple[str, float], OptHistory] = OrderedDict()
+        self._size = size
+        self._lock = threading.Lock()
+
+    def get(self, path: Path) -> OptHistory:
+        if not path.exists():
+            raise HistoryUnavailable(f"No history was saved at {path}")
+
+        key = (str(path), path.stat().st_mtime)
+        with self._lock:
+            cached = self._entries.get(key)
+            if cached is not None:
+                self._entries.move_to_end(key)
+                return cached
+
+        # Parsing outside the lock: it is slow, and a duplicate parse is cheaper
+        # than blocking every other request while one runs.
+        history = OptHistory.load(path.read_text(encoding="utf-8"))
+
+        with self._lock:
+            self._entries[key] = history
+            self._entries.move_to_end(key)
+            while len(self._entries) > self._size:
+                self._entries.popitem(last=False)
+        return history
+
+
+_cache = _HistoryCache()
+
+
+def load_history(path: Path) -> OptHistory:
+    return _cache.get(path)
+
+
+def lineage_graph(path: Path, *, only_winning_path: bool = True) -> dict[str, Any]:
+    """The genealogy of a finished run, ready for the browser."""
+    history = load_history(path)
+    graph = history_to_lineage(history, only_winning_path=only_winning_path)
+    graph["only_winning_path"] = only_winning_path
+    graph["metric_names"] = _metric_names(history)
+    graph["source"] = "history"
+    graph["is_live"] = False
+    return graph
+
+
+def live_lineage_graph(
+    events: list[dict[str, Any]], *, only_winning_path: bool = True
+) -> dict[str, Any] | None:
+    """The genealogy of a run still in progress, built from its progress events."""
+    graph = lineage_from_events(events, only_winning_path=only_winning_path)
+    if graph is None:
+        return None
+    graph["only_winning_path"] = only_winning_path
+    graph["metric_names"] = []
+    graph["source"] = "live"
+    graph["is_live"] = True
+    return graph
+
+
+def _metric_names(history: OptHistory) -> list[str]:
+    names = getattr(history, "metric_names", None)
+    if names:
+        return [str(name) for name in names]
+    objective = getattr(history, "objective", None)
+    names = getattr(objective, "metric_names", None)
+    return [str(name) for name in names] if names else []
+
+
+def individual_pipeline(path: Path, individual_uid: str) -> dict[str, Any] | None:
+    """The pipeline of one individual, in the editor's graph format.
+
+    This is what makes the lineage graph explorable: clicking a node in the
+    genealogy shows the actual pipeline that node stands for.
+    """
+    from fedot.core.pipelines.adapters import PipelineAdapter
+
+    from ..pipelines.convert import pipeline_to_graph
+
+    history = load_history(path)
+    for generation_index, population in enumerate(history.generations or []):
+        for individual in population:
+            if str(individual.uid) != individual_uid:
+                continue
+            pipeline = PipelineAdapter().restore(individual.graph)
+            described = pipeline_to_graph(pipeline, uid=individual_uid)
+            fitness = getattr(individual.fitness, "value", None)
+            described["fitness"] = float(fitness) if isinstance(fitness, (int, float)) else None
+            described["generation"] = generation_index
+            return described
+    return None
+
+
+def live_individual_pipeline(
+    events: list[dict[str, Any]], individual_uid: str
+) -> dict[str, Any] | None:
+    """The pipeline of one individual in a run that is still going."""
+    return individual_pipeline_from_events(events, individual_uid)

--- a/backend/fedotweb/main.py
+++ b/backend/fedotweb/main.py
@@ -1,0 +1,144 @@
+"""FastAPI application for FEDOT.Web."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+from .api import analysis, catalog, datasets, pipelines, runs
+from .api.deps import build_state
+from .settings import get_settings
+
+logger = logging.getLogger("fedotweb")
+
+DESCRIPTION = """
+Web interface for the [FEDOT](https://github.com/aimclub/FEDOT) AutoML framework
+and the [GOLEM](https://github.com/aimclub/GOLEM) optimiser.
+
+* **Catalog** — every operation FEDOT can use, with a typed schema for each hyperparameter.
+* **Pipelines** — build, validate, store and export pipelines.
+* **Datasets** — upload a CSV and choose a target column.
+* **Runs** — launch a composition, follow the evolution live, stop it, inspect the result.
+"""
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    settings = get_settings()
+    app.state.container = build_state()
+    logger.info("Workspace: %s", settings.workspace)
+
+    # A run whose worker this server owned died with the previous process. A run
+    # attached from a user's script is different: its events come from that
+    # script's own process, which a GUI restart does not interrupt — marking it
+    # failed would falsify a run that is still happily going.
+    store = app.state.container.store
+    for record in store.list_runs():
+        if record["status"] in {"pending", "running"}:
+            if (record.get("config") or {}).get("origin") == "attached":
+                continue
+            store.update_run(
+                record["uid"],
+                status="failed",
+                error="The server restarted while this run was in progress",
+            )
+
+    # Analyses run in worker processes owned by this server too.
+    stale = store.fail_running_analyses("The server restarted while this analysis was in progress")
+    if stale:
+        logger.info("Marked %d interrupted analyses as failed", stale)
+
+    try:
+        yield
+    finally:
+        await app.state.container.manager.shutdown()
+        await app.state.container.analyses.shutdown()
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+
+    app = FastAPI(
+        title="FEDOT.Web API",
+        version="2.0.0",
+        description=DESCRIPTION,
+        lifespan=lifespan,
+    )
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    api_prefix = "/api"
+    app.include_router(catalog.router, prefix=api_prefix)
+    app.include_router(pipelines.router, prefix=api_prefix)
+    app.include_router(datasets.router, prefix=api_prefix)
+    app.include_router(runs.router, prefix=api_prefix)
+    app.include_router(analysis.router, prefix=api_prefix)
+
+    @app.get("/api/health", tags=["meta"])
+    def health() -> JSONResponse:
+        return JSONResponse({"status": "ok", "version": app.version})
+
+    _mount_frontend(app, settings.static_dir)
+    return app
+
+
+def _mount_frontend(app: FastAPI, static_dir: Path | None) -> None:
+    """Serve the built UI from the same origin as the API, when it is present.
+
+    Falls back to a short message so a fresh checkout without a frontend build
+    still explains itself rather than returning a bare 404.
+    """
+    candidates = [static_dir] if static_dir else []
+    candidates.append(Path(__file__).resolve().parents[2] / "ui" / "dist")
+
+    build_dir = next((path for path in candidates if path and path.is_dir()), None)
+    if build_dir is None:
+        @app.get("/", include_in_schema=False)
+        def missing_frontend() -> JSONResponse:
+            return JSONResponse(
+                {
+                    "message": "The API is running, but no frontend build was found.",
+                    "docs": "/docs",
+                    "build_hint": "cd ui && npm install && npm run build",
+                }
+            )
+
+        return
+
+    assets = build_dir / "assets"
+    if assets.is_dir():
+        app.mount("/assets", StaticFiles(directory=assets), name="assets")
+
+    index = build_dir / "index.html"
+
+    @app.get("/", include_in_schema=False)
+    def index_page() -> FileResponse:
+        return FileResponse(index)
+
+    @app.get("/{full_path:path}", include_in_schema=False)
+    def spa_fallback(full_path: str) -> FileResponse:
+        # Client-side routes such as /editor must resolve to the SPA shell, but a
+        # request for a real file (favicon, manifest) should still be served.
+        # Resolving and checking containment keeps a crafted ../ path from
+        # reading files outside the build directory.
+        if full_path:
+            candidate = (build_dir / full_path).resolve()
+            if candidate.is_file() and candidate.is_relative_to(build_dir.resolve()):
+                return FileResponse(candidate)
+        return FileResponse(index)
+
+
+app = create_app()

--- a/backend/fedotweb/pipelines/__init__.py
+++ b/backend/fedotweb/pipelines/__init__.py
@@ -1,0 +1,3 @@
+﻿from .convert import graph_to_pipeline, pipeline_to_graph, validate_graph
+
+__all__ = ["graph_to_pipeline", "pipeline_to_graph", "validate_graph"]

--- a/backend/fedotweb/pipelines/convert.py
+++ b/backend/fedotweb/pipelines/convert.py
@@ -1,0 +1,241 @@
+"""Conversion between FEDOT pipelines and the graph format the editor speaks.
+
+The legacy implementation rebuilt parent nodes recursively and de-duplicated them
+by ``descriptive_id``, which silently merged distinct nodes that happened to have
+identical operations and parameters -- a diamond-shaped pipeline could come back
+with the wrong topology.  Here the graph is built in topological order instead,
+so every editor node maps to exactly one pipeline node.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import deque
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from fedot.core.pipelines.node import PipelineNode
+from fedot.core.pipelines.pipeline import Pipeline
+from fedot.core.pipelines.verification import verify_pipeline
+from fedot.core.repository.tasks import Task, TaskTypesEnum
+
+from ..catalog import get_catalog
+from ..catalog.hyperparams import _json_safe
+
+#: FEDOT writes this sentinel instead of an empty parameter dict.
+DEFAULT_PARAMS_STUB = "default_params"
+
+
+class PipelineConversionError(ValueError):
+    """Raised when an editor graph cannot be expressed as a FEDOT pipeline."""
+
+
+def _normalise_params(params: Any) -> dict[str, Any]:
+    """Coerce whatever FEDOT stored in ``node.parameters`` into a plain dict."""
+    if not params or params == DEFAULT_PARAMS_STUB:
+        return {}
+    if isinstance(params, dict):
+        return _json_safe(params)
+    return {}
+
+
+def pipeline_to_graph(pipeline: Pipeline, *, uid: str | None = None) -> dict[str, Any]:
+    """Describe a fitted or unfitted pipeline as an editor graph.
+
+    Node ids are positional (``n0``, ``n1``, ...) and stable for a given pipeline
+    object, which is what lets the UI diff two graphs.
+    """
+    catalog = get_catalog()
+    index_of: dict[int, str] = {}
+    nodes: list[dict[str, Any]] = []
+
+    for position, node in enumerate(pipeline.nodes):
+        node_id = f"n{position}"
+        index_of[id(node)] = node_id
+
+        operation_id = node.operation.operation_type
+        described = catalog.get(operation_id) or {}
+        nodes.append(
+            {
+                "id": node_id,
+                "operation": operation_id,
+                "label": operation_id,
+                "kind": described.get("kind", "model"),
+                "group": described.get("group", "model"),
+                "description": described.get("description"),
+                "tags": described.get("tags", []),
+                "params": _normalise_params(node.parameters),
+                "defaults": described.get("defaults", {}),
+                "parents": [],
+                "children": [],
+                "is_primary": not node.nodes_from,
+                "is_root": False,
+            }
+        )
+
+    by_id = {node["id"]: node for node in nodes}
+    edges: list[dict[str, str]] = []
+
+    for position, node in enumerate(pipeline.nodes):
+        node_id = f"n{position}"
+        for parent in node.nodes_from or []:
+            parent_id = index_of.get(id(parent))
+            if parent_id is None:
+                # A parent outside ``pipeline.nodes`` means the pipeline is malformed.
+                continue
+            edges.append({"id": f"{parent_id}->{node_id}", "source": parent_id, "target": node_id})
+            by_id[node_id]["parents"].append(parent_id)
+            by_id[parent_id]["children"].append(node_id)
+
+    # ``root_node`` raises when a pipeline has more than one sink; the editor must
+    # still be able to display such a graph so the user can fix it.
+    try:
+        root = pipeline.root_node if pipeline.nodes else None
+    except ValueError:
+        root = None
+    if root is not None:
+        root_id = index_of.get(id(root))
+        if root_id in by_id:
+            by_id[root_id]["is_root"] = True
+
+    return {
+        "uid": uid or "",
+        "nodes": nodes,
+        "edges": edges,
+        "depth": pipeline.depth if pipeline.nodes else 0,
+        "length": pipeline.length if pipeline.nodes else 0,
+    }
+
+
+def _topological_order(node_ids: Sequence[str], parents_of: dict[str, list[str]]) -> list[str]:
+    """Kahn's algorithm; raises when the editor graph contains a cycle."""
+    remaining = {node_id: len(parents_of.get(node_id, [])) for node_id in node_ids}
+    children_of: dict[str, list[str]] = {node_id: [] for node_id in node_ids}
+    for node_id, parents in parents_of.items():
+        for parent in parents:
+            if parent in children_of:
+                children_of[parent].append(node_id)
+
+    queue = deque(sorted(node_id for node_id, degree in remaining.items() if degree == 0))
+    order: list[str] = []
+    while queue:
+        current = queue.popleft()
+        order.append(current)
+        for child in children_of[current]:
+            remaining[child] -= 1
+            if remaining[child] == 0:
+                queue.append(child)
+
+    if len(order) != len(node_ids):
+        raise PipelineConversionError("The pipeline graph contains a cycle")
+    return order
+
+
+def graph_to_pipeline(graph: dict[str, Any]) -> Pipeline:
+    """Build a FEDOT pipeline from an editor graph.
+
+    Accepts both the string ids this backend emits and the integer ids the legacy
+    frontend used.
+    """
+    raw_nodes: Iterable[dict[str, Any]] = graph.get("nodes") or []
+    nodes_by_id: dict[str, dict[str, Any]] = {}
+    for raw in raw_nodes:
+        if "id" not in raw:
+            raise PipelineConversionError("Every node must carry an id")
+        node_id = str(raw["id"])
+        if node_id in nodes_by_id:
+            raise PipelineConversionError(f"Duplicate node id: {node_id}")
+        nodes_by_id[node_id] = raw
+
+    if not nodes_by_id:
+        raise PipelineConversionError("The pipeline is empty")
+
+    parents_of: dict[str, list[str]] = {node_id: [] for node_id in nodes_by_id}
+    for edge in graph.get("edges") or []:
+        source, target = str(edge.get("source")), str(edge.get("target"))
+        if source not in nodes_by_id:
+            raise PipelineConversionError(f"Edge refers to an unknown source node: {source}")
+        if target not in nodes_by_id:
+            raise PipelineConversionError(f"Edge refers to an unknown target node: {target}")
+        if source == target:
+            raise PipelineConversionError(f"Node {source} cannot be its own parent")
+        if source not in parents_of[target]:
+            parents_of[target].append(source)
+
+    built: dict[str, PipelineNode] = {}
+    for node_id in _topological_order(list(nodes_by_id), parents_of):
+        raw = nodes_by_id[node_id]
+        operation = raw.get("operation") or raw.get("model_name") or raw.get("display_name")
+        if not operation:
+            raise PipelineConversionError(f"Node {node_id} has no operation")
+
+        parents = [built[parent] for parent in parents_of[node_id]]
+        node = PipelineNode(str(operation), nodes_from=parents or None)
+
+        params = raw.get("params")
+        if isinstance(params, dict) and params:
+            node.parameters = _json_safe(params)
+
+        built[node_id] = node
+
+    pipeline = Pipeline(list(built.values()))
+    return pipeline
+
+
+#: FEDOT reports rule failures as one long string that embeds the rule's ``repr``
+#: and the whole graph.  Only the bracketed reason and the rule name are useful.
+_VERIFICATION_REASON = re.compile(r"<([^>]+)>")
+_RULE_NAME = re.compile(r"function (\w+) at 0x")
+
+
+def _readable_verification_error(message: str) -> str:
+    """Turn FEDOT's verification message into something worth showing a user."""
+    reason_match = _VERIFICATION_REASON.search(message)
+    if not reason_match:
+        return message.split(" on graph=")[0].strip()
+
+    reason = reason_match.group(1)
+    # Strip the "Invalid pipeline configuration:" prefix FEDOT adds to every rule.
+    reason = reason.split(":", 1)[-1].strip() if ":" in reason else reason
+
+    rule_match = _RULE_NAME.search(message)
+    if rule_match:
+        rule = rule_match.group(1).replace("_", " ")
+        return f"{reason} (rule: {rule})"
+    return reason
+
+
+def validate_graph(graph: dict[str, Any], task: str | None = None) -> tuple[bool, list[str]]:
+    """Check a graph both structurally and against FEDOT's own pipeline rules.
+
+    Unlike the legacy endpoint, the task type is taken into account, so
+    time-series-specific rules (a lagged transform before a table model, and so
+    on) are actually applied.
+    """
+    problems: list[str] = []
+    catalog = get_catalog()
+
+    for raw in graph.get("nodes") or []:
+        operation = raw.get("operation") or raw.get("model_name")
+        if operation and not catalog.exists(str(operation)):
+            problems.append(f"Unknown operation: {operation}")
+
+    try:
+        pipeline = graph_to_pipeline(graph)
+    except PipelineConversionError as exc:
+        problems.append(str(exc))
+        return False, problems
+
+    task_obj = None
+    if task:
+        try:
+            task_obj = Task(TaskTypesEnum(task))
+        except ValueError:
+            problems.append(f"Unknown task type: {task}")
+
+    try:
+        verify_pipeline(pipeline, task_type=task_obj.task_type if task_obj else None, raise_on_failure=True)
+    except Exception as exc:  # FEDOT raises ValueError subclasses with rule-specific messages
+        problems.append(_readable_verification_error(str(exc)))
+
+    return not problems, problems

--- a/backend/fedotweb/runs/__init__.py
+++ b/backend/fedotweb/runs/__init__.py
@@ -1,0 +1,3 @@
+﻿from .manager import RunError, RunManager
+
+__all__ = ["RunError", "RunManager"]

--- a/backend/fedotweb/runs/control.py
+++ b/backend/fedotweb/runs/control.py
@@ -1,0 +1,236 @@
+"""Changing how the evolution behaves while it is running.
+
+GOLEM re-derives several of its own parameters at the start of every generation:
+``_update_requirements`` overwrites ``pop_size`` and the mutation and crossover
+probabilities from adaptive sources. Assigning to those fields from outside would
+therefore last exactly until the next generation began.
+
+So the controls here work at the source. Population size and operator
+probabilities are supplied by objects implementing GOLEM's ``AdaptiveParameter``
+protocol; wrapping those lets an override survive the adaptive update. The
+remaining knobs -- generation count and time budget -- are read live by the
+optimiser's stopping conditions and can simply be assigned.
+
+The GUI and the worker are separate processes, so requests travel through a small
+JSON file in the run directory, which the worker reads between generations. A
+generation is never interrupted mid-flight.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Any
+
+CONTROL_FILE = "control.json"
+
+#: Bounds applied to whatever the client asks for, so a typo cannot wedge a run.
+LIMITS = {
+    "pop_size": (2, 500),
+    "num_of_generations": (1, 10_000),
+    "timeout_minutes": (0.1, 100_000.0),
+    "mutation_prob": (0.0, 1.0),
+    "crossover_prob": (0.0, 1.0),
+}
+
+
+@dataclass
+class EvolutionControls:
+    """Values the user has asked for. ``None`` means "leave GOLEM in charge"."""
+
+    pop_size: int | None = None
+    num_of_generations: int | None = None
+    timeout_minutes: float | None = None
+    mutation_prob: float | None = None
+    crossover_prob: float | None = None
+    #: Stop after the current generation, keeping the best pipeline found so far.
+    finish_now: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _clamp(name: str, value: Any) -> Any:
+    limits = LIMITS.get(name)
+    if limits is None or value is None:
+        return value
+    low, high = limits
+    return min(max(value, low), high)
+
+
+def coerce_patch(patch: dict[str, Any]) -> dict[str, Any]:
+    """Keep only known fields, and hold each within its safe range."""
+    known = {field.name for field in fields(EvolutionControls)}
+    cleaned: dict[str, Any] = {}
+    for name, value in patch.items():
+        if name not in known:
+            continue
+        if name == "finish_now":
+            cleaned[name] = bool(value)
+        elif value is None:
+            cleaned[name] = None
+        elif name in ("pop_size", "num_of_generations"):
+            cleaned[name] = int(_clamp(name, int(value)))
+        else:
+            cleaned[name] = float(_clamp(name, float(value)))
+    return cleaned
+
+
+def read_controls(run_dir: Path) -> EvolutionControls:
+    path = run_dir / CONTROL_FILE
+    if not path.exists():
+        return EvolutionControls()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        # A half-written file is transient; the next read picks up the new one.
+        return EvolutionControls()
+    return EvolutionControls(**coerce_patch(payload))
+
+
+def write_controls(run_dir: Path, patch: dict[str, Any]) -> EvolutionControls:
+    """Merge a patch into the stored controls and return the result."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    current = read_controls(run_dir).as_dict()
+    current.update(coerce_patch(patch))
+
+    merged = EvolutionControls(**current)
+    path = run_dir / CONTROL_FILE
+    # Write-then-replace so a reader never sees a partial file.
+    staging = path.with_suffix(".json.tmp")
+    staging.write_text(json.dumps(merged.as_dict(), ensure_ascii=False), encoding="utf-8")
+    staging.replace(path)
+    return merged
+
+
+class OverridableParameter:
+    """Wraps a GOLEM ``AdaptiveParameter`` so a fixed value can take over.
+
+    While ``override`` is ``None`` the wrapped policy is untouched, so a run left
+    alone behaves exactly as it would without the GUI attached.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.override: Any = None
+
+    @property
+    def initial(self) -> Any:
+        return self._inner.initial
+
+    def next(self, population: Any) -> Any:
+        # The wrapped policy is still advanced, so releasing the override resumes
+        # the adaptive schedule from where it would have been.
+        value = self._inner.next(population)
+        return value if self.override is None else self.override
+
+
+class OverridableOperatorProbabilities(OverridableParameter):
+    """The mutation/crossover pair, each independently overridable."""
+
+    def __init__(self, inner: Any) -> None:
+        super().__init__(inner)
+        self.mutation_override: float | None = None
+        self.crossover_override: float | None = None
+
+    def next(self, population: Any) -> Any:
+        mutation, crossover = self._inner.next(population)
+        return (
+            mutation if self.mutation_override is None else self.mutation_override,
+            crossover if self.crossover_override is None else self.crossover_override,
+        )
+
+
+def install_overrides(optimizer: Any) -> None:
+    """Replace the optimiser's adaptive parameter sources with overridable ones."""
+    if getattr(optimizer, "_fedotweb_overrides", False):
+        return
+    optimizer._pop_size = OverridableParameter(optimizer._pop_size)
+    optimizer._operators_prob = OverridableOperatorProbabilities(optimizer._operators_prob)
+    optimizer._fedotweb_overrides = True
+
+
+def apply_controls(optimizer: Any, controls: EvolutionControls) -> list[str]:
+    """Apply the requested controls to a live optimiser.
+
+    Returns a human-readable description of everything that actually changed, so
+    the run log can show what took effect and when.
+    """
+    applied: list[str] = []
+    params = optimizer.graph_optimizer_params
+    requirements = optimizer.requirements
+
+    if controls.pop_size is not None and optimizer._pop_size.override != controls.pop_size:
+        optimizer._pop_size.override = controls.pop_size
+        # Also set it directly, so the change lands on the coming generation
+        # rather than the one after it.
+        params.pop_size = controls.pop_size
+        applied.append(f"population size → {controls.pop_size}")
+    elif controls.pop_size is None and optimizer._pop_size.override is not None:
+        optimizer._pop_size.override = None
+        applied.append("population size → adaptive")
+
+    probabilities = optimizer._operators_prob
+    if controls.mutation_prob is not None and probabilities.mutation_override != controls.mutation_prob:
+        probabilities.mutation_override = controls.mutation_prob
+        params.mutation_prob = controls.mutation_prob
+        applied.append(f"mutation probability → {controls.mutation_prob:g}")
+    elif controls.mutation_prob is None and probabilities.mutation_override is not None:
+        probabilities.mutation_override = None
+        applied.append("mutation probability → adaptive")
+
+    if controls.crossover_prob is not None and probabilities.crossover_override != controls.crossover_prob:
+        probabilities.crossover_override = controls.crossover_prob
+        params.crossover_prob = controls.crossover_prob
+        applied.append(f"crossover probability → {controls.crossover_prob:g}")
+    elif controls.crossover_prob is None and probabilities.crossover_override is not None:
+        probabilities.crossover_override = None
+        applied.append("crossover probability → adaptive")
+
+    if (
+        controls.num_of_generations is not None
+        and requirements.num_of_generations != controls.num_of_generations
+    ):
+        requirements.num_of_generations = controls.num_of_generations
+        applied.append(f"generation limit → {controls.num_of_generations}")
+
+    if controls.timeout_minutes is not None:
+        wanted = datetime.timedelta(minutes=controls.timeout_minutes)
+        if optimizer.timer.timeout != wanted:
+            optimizer.timer.timeout = wanted
+            requirements.timeout = wanted
+            applied.append(f"time budget → {controls.timeout_minutes:g} min")
+
+    if controls.finish_now:
+        # Ending through the generation limit lets the optimiser return normally,
+        # so FEDOT still fits and hands back the best pipeline it found. Killing
+        # the process would throw that away.
+        #
+        # GOLEM stops once ``current_generation_num >= num_of_generations + 1``,
+        # so the limit has to go one below the current generation for the loop to
+        # exit at its next check rather than running another whole generation.
+        current = int(getattr(optimizer, "current_generation_num", 0))
+        target = max(0, current - 1)
+        if requirements.num_of_generations is None or requirements.num_of_generations > target:
+            requirements.num_of_generations = target
+            applied.append("finishing now, keeping the best result so far")
+
+    return applied
+
+
+def describe_effective(optimizer: Any) -> dict[str, Any]:
+    """What the optimiser is currently using, for display next to the controls."""
+    params = optimizer.graph_optimizer_params
+    requirements = optimizer.requirements
+    timeout = getattr(optimizer.timer, "timeout", None)
+    return {
+        "pop_size": getattr(params, "pop_size", None),
+        "mutation_prob": getattr(params, "mutation_prob", None),
+        "crossover_prob": getattr(params, "crossover_prob", None),
+        "num_of_generations": getattr(requirements, "num_of_generations", None),
+        "timeout_minutes": timeout.total_seconds() / 60 if timeout else None,
+        "max_depth": getattr(requirements, "max_depth", None),
+        "generation": int(getattr(optimizer, "current_generation_num", 0)),
+    }

--- a/backend/fedotweb/runs/evaltrace.py
+++ b/backend/fedotweb/runs/evaltrace.py
@@ -1,0 +1,388 @@
+"""What the evaluator is doing right now, pipeline by pipeline, fold by fold.
+
+A generation of AutoML is minutes of silence: the optimiser only reports when a
+whole population is done, while the actual time goes into fitting individual
+pipelines fold after fold. This module opens that box. The objective evaluator
+is wrapped so that every evaluation writes what it is doing -- which pipeline,
+which fold, which node is fitting at this moment -- and the server aggregates
+those notes into a live picture.
+
+The notes travel by file, not by socket, because with ``n_jobs > 1`` GOLEM
+evaluates pipelines in separate processes (joblib): the wrapper object is
+pickled into each of them, and each process appends to its own
+``<run_dir>/evals/<pid>.jsonl``. One writer per file means no locking, and the
+server merges the files on request.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+#: Subdirectory of a run's directory where the trace files live.
+TRACE_DIR_NAME = "evals"
+
+#: An "active" evaluation with no end event and older than this is presumed
+#: dead (its process was killed) and is not shown.
+STALE_AFTER_SECONDS = 3600.0
+
+#: How much of each trace file's tail the server reads. Enough for hundreds of
+#: recent events; older history is only needed for totals, which are counted
+#: from what is read.
+TAIL_BYTES = 512 * 1024
+
+
+class _TraceWriter:
+    """Appends one JSON line per event to this process's own trace files.
+
+    Node fits go to a separate file: they outnumber evaluation events by an
+    order of magnitude, and keeping them apart lets the reader tail the small
+    file far enough back to count every evaluation of a long run.
+    """
+
+    def __init__(self, directory: str) -> None:
+        self._directory = directory
+        self._files: dict[str, Any] = {}
+
+    def emit(self, kind: str, **payload: Any) -> None:
+        # Tracing must never break an evaluation, whatever the failure.
+        try:
+            suffix = "-nodes" if kind == "node" else ""
+            handle = self._files.get(suffix)
+            if handle is None:
+                Path(self._directory).mkdir(parents=True, exist_ok=True)
+                path = Path(self._directory) / f"{os.getpid()}{suffix}.jsonl"
+                handle = open(path, "a", encoding="utf-8")
+                self._files[suffix] = handle
+            record = {"ts": time.time(), "kind": kind, **payload}
+            handle.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+            handle.flush()
+        except Exception:
+            pass
+
+
+#: Per-process singletons: the writer, and the context node-level events attach
+#: to. Evaluations within one process are sequential, so a plain dict is safe.
+_writers: dict[str, _TraceWriter] = {}
+_current: dict[str, Any] = {}
+_node_patch_installed = False
+
+
+def _writer_for(directory: str) -> _TraceWriter:
+    writer = _writers.get(directory)
+    if writer is None:
+        writer = _TraceWriter(directory)
+        _writers[directory] = writer
+    return writer
+
+
+def _operations_of(graph: Any) -> list[str]:
+    names = []
+    for node in getattr(graph, "nodes", None) or []:
+        name = getattr(node, "name", None)
+        if name is None:
+            name = getattr(node, "content", {}).get("name")
+        names.append(str(name))
+    return names
+
+
+def _install_node_patch() -> None:
+    """Report every node fit of this process, with the current evaluation's context.
+
+    Installed lazily in whichever process evaluates, so it follows the wrapper
+    into joblib workers without any start-up hook.
+    """
+    global _node_patch_installed
+    if _node_patch_installed:
+        return
+    try:
+        from fedot.core.pipelines.node import PipelineNode
+    except Exception:
+        return
+
+    original = PipelineNode.fit
+
+    def traced_fit(self: Any, *args: Any, **kwargs: Any) -> Any:
+        writer = _current.get("writer")
+        if writer is None:
+            return original(self, *args, **kwargs)
+        operation = str(
+            getattr(getattr(self, "operation", None), "operation_type", None)
+            or getattr(self, "name", "node")
+        )
+        info = dict(_current.get("info") or {})
+        writer.emit("node", stage="fit_start", operation=operation, **info)
+        started = time.monotonic()
+        try:
+            result = original(self, *args, **kwargs)
+        except Exception as exc:
+            writer.emit(
+                "node",
+                stage="fit_failed",
+                operation=operation,
+                seconds=round(time.monotonic() - started, 3),
+                error=str(exc)[:200],
+                **info,
+            )
+            raise
+        writer.emit(
+            "node",
+            stage="fit_done",
+            operation=operation,
+            seconds=round(time.monotonic() - started, 3),
+            **info,
+        )
+        return result
+
+    PipelineNode.fit = traced_fit
+    _node_patch_installed = True
+
+
+def begin_main_process_trace(run_dir: Path) -> None:
+    """Trace node fits that happen outside evolution, in the worker itself.
+
+    The initial assumptions are fitted before the optimiser starts and the
+    winning pipeline is refitted after it returns; both can take minutes and
+    both used to be silent. Evaluations overwrite this context while they run.
+    """
+    _install_node_patch()
+    _current["writer"] = _writer_for(str(run_dir / TRACE_DIR_NAME))
+    _current["info"] = {"phase": "preparation"}
+
+
+class _TracingDataProducer:
+    """Wraps the fold producer so entering each fold leaves a note."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    def __getattr__(self, name: str) -> Any:
+        # ``evaluate_intermediate_metrics`` reaches for ``_data_producer.args``.
+        return getattr(self._inner, name)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        for fold_id, fold in enumerate(self._inner(*args, **kwargs)):
+            info = _current.get("info")
+            if info is not None:
+                info["fold"] = fold_id
+                writer = _current.get("writer")
+                if writer is not None:
+                    writer.emit("fold", **info)
+            yield fold
+
+
+class TracingObjectiveEvaluate:
+    """An ``ObjectiveEvaluate`` that reports what it is doing while it works.
+
+    Behaves exactly like the wrapped evaluator; the only addition is the trail
+    of events. Picklable, and meant to be: joblib carries it into the worker
+    processes, where the trace file is recreated lazily per process.
+    """
+
+    def __init__(self, inner: Any, trace_dir: str) -> None:
+        self._inner = inner
+        self._trace_dir = trace_dir
+
+    @classmethod
+    def wrap(cls, objective: Any, run_dir: Path) -> "TracingObjectiveEvaluate":
+        if isinstance(objective, cls):
+            return objective
+        return cls(objective, str(Path(run_dir) / TRACE_DIR_NAME))
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {"inner": self._inner, "trace_dir": self._trace_dir}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self._inner = state["inner"]
+        self._trace_dir = state["trace_dir"]
+
+    def __getattr__(self, name: str) -> Any:
+        # ``self.__dict__`` directly: during unpickling ``_inner`` does not
+        # exist yet, and going through ``self._inner`` would recurse forever.
+        inner = self.__dict__.get("_inner")
+        if inner is None:
+            raise AttributeError(name)
+        try:
+            return getattr(inner, name)
+        except AttributeError:
+            # The composer passes the evaluator's *bound method*, so requests
+            # for the evaluator's own attributes go to the object behind it.
+            target = getattr(inner, "__self__", None)
+            if target is None:
+                raise
+            return getattr(target, name)
+
+    def __call__(self, graph: Any) -> Any:
+        return self.evaluate(graph)
+
+    def _ensure_fold_tracing(self) -> None:
+        # ``inner`` is either an ``ObjectiveEvaluate`` or its bound
+        # ``evaluate`` method; the fold producer lives on the object.
+        target = getattr(self._inner, "__self__", self._inner)
+        producer = getattr(target, "_data_producer", None)
+        if producer is not None and not isinstance(producer, _TracingDataProducer):
+            target._data_producer = _TracingDataProducer(producer)
+
+    def evaluate(self, graph: Any) -> Any:
+        writer = _writer_for(self._trace_dir)
+        self._ensure_fold_tracing()
+        _install_node_patch()
+
+        info = {
+            "eval_id": f"{os.getpid()}-{time.monotonic_ns()}",
+            "ops": _operations_of(graph),
+        }
+        _current["writer"] = writer
+        _current["info"] = info
+        writer.emit("evaluation", stage="start", **info)
+        started = time.monotonic()
+        inner = self._inner
+        call = inner.evaluate if hasattr(inner, "evaluate") else inner
+        try:
+            fitness = call(graph)
+        except Exception as exc:
+            writer.emit(
+                "evaluation",
+                stage="failed",
+                seconds=round(time.monotonic() - started, 3),
+                error=str(exc)[:200],
+                **info,
+            )
+            _current.pop("writer", None)
+            _current.pop("info", None)
+            raise
+        values = list(getattr(fitness, "values", None) or [])
+        valid = bool(getattr(fitness, "valid", False))
+        writer.emit(
+            "evaluation",
+            stage="done" if valid else "invalid",
+            seconds=round(time.monotonic() - started, 3),
+            fitness=values[0] if valid and values else None,
+            **info,
+        )
+        _current.pop("writer", None)
+        _current.pop("info", None)
+        return fitness
+
+
+# --------------------------------------------------------------------- reading
+
+
+def _tail_lines(path: Path) -> list[dict[str, Any]]:
+    try:
+        size = path.stat().st_size
+        with open(path, "rb") as handle:
+            if size > TAIL_BYTES:
+                handle.seek(size - TAIL_BYTES)
+                handle.readline()  # drop the line that was cut in half
+            raw = handle.read().decode("utf-8", errors="replace")
+    except OSError:
+        return []
+    events = []
+    for line in raw.splitlines():
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+def read_evaluation_state(run_dir: Path) -> dict[str, Any]:
+    """Merge the trace files into one picture of the evaluator's work."""
+    directory = Path(run_dir) / TRACE_DIR_NAME
+    events: list[dict[str, Any]] = []
+    if directory.is_dir():
+        for path in directory.glob("*.jsonl"):
+            events.extend(_tail_lines(path))
+    events.sort(key=lambda event: event.get("ts") or 0)
+
+    now = time.time()
+    active: dict[str, dict[str, Any]] = {}
+    recent: list[dict[str, Any]] = []
+    done = failed = 0
+    durations: list[float] = []
+    preparing: dict[str, Any] | None = None
+
+    for event in events:
+        kind = event.get("kind")
+        eval_id = event.get("eval_id")
+
+        if kind == "evaluation":
+            stage = event.get("stage")
+            if stage == "start" and eval_id:
+                active[eval_id] = {
+                    "ops": event.get("ops") or [],
+                    "fold": None,
+                    "node": None,
+                    "started": event.get("ts") or now,
+                }
+            elif eval_id:
+                entry = active.pop(eval_id, None)
+                seconds = event.get("seconds")
+                if stage == "done":
+                    done += 1
+                    if isinstance(seconds, (int, float)):
+                        durations.append(float(seconds))
+                else:
+                    failed += 1
+                recent.append(
+                    {
+                        "ops": event.get("ops") or (entry or {}).get("ops") or [],
+                        "seconds": seconds,
+                        "fitness": event.get("fitness"),
+                        "failed": stage != "done",
+                        "error": event.get("error"),
+                        "finished": event.get("ts"),
+                    }
+                )
+        elif kind == "fold" and eval_id and eval_id in active:
+            active[eval_id]["fold"] = event.get("fold")
+        elif kind == "node":
+            stage = event.get("stage")
+            if eval_id and eval_id in active:
+                active[eval_id]["node"] = (
+                    event.get("operation") if stage == "fit_start" else None
+                )
+            elif event.get("phase") == "preparation":
+                if stage == "fit_start":
+                    preparing = {"node": event.get("operation"), "since": event.get("ts")}
+                else:
+                    preparing = None
+
+    active_list = [
+        {
+            "ops": entry["ops"],
+            "fold": entry["fold"],
+            "node": entry["node"],
+            "seconds": round(max(0.0, now - float(entry["started"])), 1),
+        }
+        for entry in active.values()
+        if now - float(entry["started"]) < STALE_AFTER_SECONDS
+    ]
+    active_list.sort(key=lambda entry: -entry["seconds"])
+
+    if preparing is not None and active_list:
+        # Evolution has taken over; the preparation note is history.
+        preparing = None
+
+    return {
+        "active": active_list,
+        "preparing": (
+            {
+                "node": preparing["node"],
+                "seconds": round(max(0.0, now - float(preparing["since"] or now)), 1),
+            }
+            if preparing
+            else None
+        ),
+        "recent": list(reversed(recent[-20:])),
+        "totals": {
+            "done": done,
+            "failed": failed,
+            "active": len(active_list),
+            "mean_seconds": round(sum(durations) / len(durations), 2) if durations else None,
+        },
+    }

--- a/backend/fedotweb/runs/manager.py
+++ b/backend/fedotweb/runs/manager.py
@@ -1,0 +1,307 @@
+"""Supervision of AutoML runs: spawning, progress fan-out and cancellation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from ..settings import Settings
+from ..storage.sqlite import Store, utcnow
+from .worker import CONFIG_FILE, EVENTS_FILE
+
+#: Statuses a run can be in.  ``pending`` and ``running`` are the only live ones.
+TERMINAL_STATUSES = frozenset({"finished", "failed", "cancelled"})
+
+#: How often the event tail polls the worker's JSONL file.
+POLL_INTERVAL_SECONDS = 0.4
+
+
+class RunError(RuntimeError):
+    """Raised when a run cannot be started or cancelled."""
+
+
+class _Subscribers:
+    """Fan-out of run events to any number of WebSocket listeners."""
+
+    def __init__(self) -> None:
+        self._queues: dict[str, set[asyncio.Queue]] = {}
+
+    def add(self, run_uid: str) -> asyncio.Queue:
+        queue: asyncio.Queue = asyncio.Queue(maxsize=1000)
+        self._queues.setdefault(run_uid, set()).add(queue)
+        return queue
+
+    def remove(self, run_uid: str, queue: asyncio.Queue) -> None:
+        listeners = self._queues.get(run_uid)
+        if not listeners:
+            return
+        listeners.discard(queue)
+        if not listeners:
+            self._queues.pop(run_uid, None)
+
+    def publish(self, run_uid: str, event: dict[str, Any]) -> None:
+        for queue in list(self._queues.get(run_uid, ())):
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                # A listener that cannot keep up is dropped rather than allowed to
+                # stall the run; the client can refetch the event log on reconnect.
+                self.remove(run_uid, queue)
+
+
+class RunManager:
+    """Owns the worker processes and turns their output into stored events."""
+
+    def __init__(self, store: Store, settings: Settings) -> None:
+        self._store = store
+        self._settings = settings
+        self._processes: dict[str, subprocess.Popen] = {}
+        self._tails: dict[str, asyncio.Task] = {}
+        #: Runs the user stopped. A killed worker cannot write its own farewell
+        #: event, so without this the tail would finalise them as failures.
+        self._cancelled: set[str] = set()
+        self._subscribers = _Subscribers()
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------ helpers
+
+    def run_dir(self, run_uid: str) -> Path:
+        return self._settings.runs_dir / run_uid
+
+    @property
+    def active_runs(self) -> list[str]:
+        return [uid for uid, process in self._processes.items() if process.poll() is None]
+
+    def is_running(self, run_uid: str) -> bool:
+        process = self._processes.get(run_uid)
+        return process is not None and process.poll() is None
+
+    # -------------------------------------------------------------------- start
+
+    async def start(self, run_uid: str, config: dict[str, Any]) -> None:
+        async with self._lock:
+            if self.is_running(run_uid):
+                raise RunError(f"Run {run_uid} is already in progress")
+            if len(self.active_runs) >= self._settings.max_concurrent_runs:
+                raise RunError(
+                    f"Too many runs in progress (limit is {self._settings.max_concurrent_runs}); "
+                    "wait for one to finish or stop it"
+                )
+
+            directory = self.run_dir(run_uid)
+            directory.mkdir(parents=True, exist_ok=True)
+            (directory / CONFIG_FILE).write_text(
+                json.dumps(config, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+            # A fresh event log per attempt keeps replay unambiguous.
+            (directory / EVENTS_FILE).write_text("", encoding="utf-8")
+
+            environment = os.environ.copy()
+            # The worker imports ``fedotweb`` itself, so it must find the package.
+            package_root = str(Path(__file__).resolve().parents[2])
+            environment["PYTHONPATH"] = os.pathsep.join(
+                filter(None, [package_root, environment.get("PYTHONPATH", "")])
+            )
+            environment["PYTHONUNBUFFERED"] = "1"
+
+            log_file = (directory / "worker.log").open("w", encoding="utf-8")
+            creation_flags = 0
+            if sys.platform == "win32":
+                # Own process group so that cancellation does not signal the API server.
+                creation_flags = subprocess.CREATE_NEW_PROCESS_GROUP
+
+            process = subprocess.Popen(
+                [sys.executable, "-m", "fedotweb.runs.worker", str(directory)],
+                cwd=package_root,
+                env=environment,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                creationflags=creation_flags,
+                start_new_session=sys.platform != "win32",
+            )
+            self._processes[run_uid] = process
+
+            self._store.update_run(run_uid, status="running", started_at=utcnow())
+            self._tails[run_uid] = asyncio.create_task(self._tail(run_uid, log_file))
+
+    # --------------------------------------------------------------------- tail
+
+    async def _tail(self, run_uid: str, log_file: Any) -> None:
+        """Stream the worker's event log into storage and to subscribers."""
+        directory = self.run_dir(run_uid)
+        events_path = directory / EVENTS_FILE
+        offset = 0
+        buffer = ""
+        final_status = "failed"
+        error_message: str | None = None
+
+        try:
+            while True:
+                process = self._processes.get(run_uid)
+                process_alive = process is not None and process.poll() is None
+
+                if events_path.exists():
+                    with events_path.open("r", encoding="utf-8") as handle:
+                        handle.seek(offset)
+                        chunk = handle.read()
+                        offset = handle.tell()
+                    buffer += chunk
+                    lines = buffer.split("\n")
+                    # The last element is a possibly-incomplete line; keep it buffered.
+                    buffer = lines.pop()
+                    for line in lines:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            event = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        kind = event.get("kind", "log")
+                        payload = event.get("payload", {})
+                        if kind == "finished":
+                            final_status = "finished"
+                        elif kind == "error":
+                            final_status = "failed"
+                            error_message = payload.get("message")
+                        elif kind == "cancelled":
+                            final_status = "cancelled"
+                        self._record(run_uid, kind, payload, elapsed=event.get("elapsed"))
+
+                # Stop only once the worker is gone *and* its log has been drained,
+                # so the final event is never lost to a race with the exit.
+                unread = events_path.exists() and offset < events_path.stat().st_size
+                if not process_alive and not buffer and not unread:
+                    break
+
+                await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+            await self._finalise(run_uid, final_status, error_message)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - the tail must never take down the server
+            self._record(run_uid, "error", {"message": f"progress reader failed: {exc}"})
+            await self._finalise(run_uid, "failed", str(exc))
+        finally:
+            with suppress(Exception):
+                log_file.close()
+
+    def _record(self, run_uid: str, kind: str, payload: dict[str, Any], elapsed: float | None = None) -> None:
+        event_id = self._store.append_event(run_uid, kind, payload)
+        self._subscribers.publish(
+            run_uid, {"id": event_id, "kind": kind, "payload": payload, "elapsed": elapsed}
+        )
+
+    async def _finalise(self, run_uid: str, status: str, error: str | None) -> None:
+        directory = self.run_dir(run_uid)
+
+        if run_uid in self._cancelled:
+            # A killed worker never gets to report its own outcome, so the tail
+            # would otherwise record the user's stop as a failure.
+            self._cancelled.discard(run_uid)
+            status, error = "cancelled", None
+
+        updates: dict[str, Any] = {"status": status, "finished_at": utcnow()}
+        if error:
+            updates["error"] = error
+
+        result_path = directory / "result.json"
+        if status == "finished" and result_path.exists():
+            try:
+                result = json.loads(result_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                result = {}
+            if result.get("metrics"):
+                updates["metrics"] = result["metrics"]
+            best_graph = result.get("best_pipeline")
+            if best_graph:
+                run = self._store.get_run(run_uid) or {}
+                pipeline_uid = self._store.save_pipeline(
+                    graph=best_graph,
+                    name=f"{run.get('name', 'run')} — best pipeline",
+                    task=(run.get("config") or {}).get("problem"),
+                    origin="automl",
+                    run_uid=run_uid,
+                )
+                updates["best_pipeline"] = pipeline_uid
+
+        self._store.update_run(run_uid, **updates)
+        self._processes.pop(run_uid, None)
+        # The tail task is about to return; dropping the reference here keeps the
+        # dict from growing by one entry per run for the life of the server.
+        self._tails.pop(run_uid, None)
+        self._subscribers.publish(run_uid, {"kind": "run_status", "payload": updates})
+
+    # ------------------------------------------------------------------- cancel
+
+    async def cancel(self, run_uid: str) -> bool:
+        process = self._processes.get(run_uid)
+        if process is None or process.poll() is not None:
+            return False
+
+        self._cancelled.add(run_uid)
+        _terminate_tree(process)
+        self._record(run_uid, "cancelled", {"message": "Run cancelled by user"})
+        # ``_tail`` notices the dead process and finalises; force the status here so
+        # a slow poll cannot leave the run looking alive.
+        self._store.update_run(run_uid, status="cancelled", finished_at=utcnow())
+        return True
+
+    async def shutdown(self) -> None:
+        for run_uid in list(self._processes):
+            with suppress(Exception):
+                await self.cancel(run_uid)
+        for task in list(self._tails.values()):
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        self._tails.clear()
+
+    # --------------------------------------------------------------- subscribe
+
+    def subscribe(self, run_uid: str) -> asyncio.Queue:
+        return self._subscribers.add(run_uid)
+
+    def unsubscribe(self, run_uid: str, queue: asyncio.Queue) -> None:
+        self._subscribers.remove(run_uid, queue)
+
+
+def _terminate_tree(process: subprocess.Popen) -> None:
+    """Kill the worker and anything it spawned.
+
+    FEDOT starts its own worker processes when ``n_jobs > 1``; killing only the
+    direct child would leave those running and holding the dataset open.
+    """
+    try:
+        import psutil  # FEDOT depends on psutil, so it is always available.
+
+        parent = psutil.Process(process.pid)
+        children = parent.children(recursive=True)
+        for child in children:
+            with suppress(psutil.Error):
+                child.terminate()
+        psutil.wait_procs(children, timeout=5)
+        for child in children:
+            with suppress(psutil.Error):
+                if child.is_running():
+                    child.kill()
+        with suppress(psutil.Error):
+            parent.terminate()
+            parent.wait(timeout=5)
+        with suppress(psutil.Error):
+            if parent.is_running():
+                parent.kill()
+    except Exception:
+        # Fall back to the plain subprocess API if psutil is unavailable.
+        with suppress(Exception):
+            process.terminate()
+        with suppress(Exception):
+            process.wait(timeout=5)
+        with suppress(Exception):
+            process.kill()

--- a/backend/fedotweb/runs/worker.py
+++ b/backend/fedotweb/runs/worker.py
@@ -358,6 +358,13 @@ def run(run_dir: Path) -> int:
             "with_tuning": bool(config.get("with_tuning", True)),
             "cv_folds": int(config.get("cv_folds") or 5),
             "early_stopping_iterations": config.get("early_stopping_iterations"),
+            # FEDOT's default stops a run after 10 minutes without improvement,
+            # which silently truncates any long budget. The user's time budget is
+            # the contract here; explicit stagnation control stays available via
+            # early_stopping_iterations.
+            "early_stopping_timeout": float(
+                config.get("early_stopping_timeout") or config.get("timeout") or 5.0
+            ),
         }
         if config.get("metric"):
             composer_params["metric"] = config["metric"]

--- a/backend/fedotweb/runs/worker.py
+++ b/backend/fedotweb/runs/worker.py
@@ -129,6 +129,62 @@ def _patch_logger_kwargs() -> bool:
     return True
 
 
+def _honor_available_operations(operations: list[str]) -> None:
+    """Make FEDOT's mutations respect an explicit ``available_operations`` list.
+
+    Three places rebuild their own operation lists from repository tags
+    instead of taking the user's list, and each silently drops operations the
+    default tag filter excludes (``qda``, ``mlp`` and ``dt`` are tagged
+    deprecated or non-default): ``PipelineOperationRepository.
+    from_available_operations`` intersects the list with the preset's
+    operation set, ``PipelineChangeAdvisor`` rebuilds its model /
+    data-operation lists with the default filter before vetoing node
+    replacements and new parents, and ``has_no_conflicts_during_multitask``
+    treats any operation outside the filtered classification list as solving
+    a foreign task and rejects the whole offspring at verification. The
+    initial assumptions and the "Set of candidate models" log line both
+    honour the full list, so the loss is invisible: evolution simply never
+    keeps those operations. Until that is fixed upstream, make all three
+    honour the requested list — the repository and advisor take the list
+    verbatim, and the default tag exclusion is lifted so the verifier
+    recognises the listed operations as native to the task. Runs without an
+    explicit list are unaffected because this is only called when the user
+    supplied one.
+    """
+    from fedot.core.pipelines.pipeline_advisor import PipelineChangeAdvisor
+    from fedot.core.repository.operation_types_repository import (
+        OperationTypesRepository,
+    )
+    from fedot.core.repository.pipeline_operation_repository import (
+        PipelineOperationRepository,
+    )
+
+    def from_available_operations(self, task, preset, available_operations):
+        primary, secondary = self.divide_operations(sorted(set(available_operations)), task)
+        self.operations_by_keys = {"primary": primary, "secondary": secondary}
+
+    PipelineOperationRepository.from_available_operations = from_available_operations
+
+    wanted = set(operations)
+    original_init = PipelineChangeAdvisor.__init__
+
+    def advisor_init(self, task=None):
+        original_init(self, task)
+        all_models = {op.id for op in OperationTypesRepository("model").operations}
+        self.models = sorted(set(self.models) | (wanted & all_models))
+        self.data_operations = sorted(set(self.data_operations) | (wanted - all_models))
+
+    PipelineChangeAdvisor.__init__ = advisor_init
+
+    original_repo_init = OperationTypesRepository.__init__
+
+    def repo_init(self, operation_type="model"):
+        original_repo_init(self, operation_type)
+        self._tags_excluded_by_default = []
+
+    OperationTypesRepository.__init__ = repo_init
+
+
 def _build_task(problem: str, config: dict[str, Any]):
     from fedot.core.repository.tasks import TsForecastingParams
 
@@ -370,6 +426,7 @@ def run(run_dir: Path) -> int:
             composer_params["metric"] = config["metric"]
         if config.get("available_operations"):
             composer_params["available_operations"] = list(config["available_operations"])
+            _honor_available_operations(composer_params["available_operations"])
         if config.get("initial_pipeline"):
             from ..pipelines.convert import graph_to_pipeline
 

--- a/backend/fedotweb/runs/worker.py
+++ b/backend/fedotweb/runs/worker.py
@@ -271,6 +271,7 @@ def _make_progress_optimizer(events: EventWriter, state: dict[str, Any], run_dir
     from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
 
     from .control import apply_controls, describe_effective, install_overrides, read_controls
+    from .evaltrace import TracingObjectiveEvaluate
 
     def on_iteration(population, optimizer) -> None:
         try:
@@ -316,6 +317,11 @@ def _make_progress_optimizer(events: EventWriter, state: dict[str, Any], run_dir
                 apply_controls(self, read_controls(run_dir))
             except Exception:
                 pass
+
+        def optimise(self, objective):
+            # Every evaluation reports pipeline, fold and node as it works; the
+            # wrapper rides into the joblib worker processes with the objective.
+            return super().optimise(TracingObjectiveEvaluate.wrap(objective, run_dir))
 
     return ProgressReportingOptimizer
 
@@ -447,6 +453,11 @@ def run(run_dir: Path) -> int:
         )
 
         events.emit("status", status="composing")
+        # The assumption fit and the final refit are minutes of silence without
+        # this; the evaluation monitor shows their node fits too.
+        from .evaltrace import begin_main_process_trace
+
+        begin_main_process_trace(run_dir)
         model.fit(features=train_data)
 
         if state["last_generation"] == 0:

--- a/backend/fedotweb/runs/worker.py
+++ b/backend/fedotweb/runs/worker.py
@@ -1,0 +1,464 @@
+"""Subprocess entry point that runs one FEDOT AutoML job.
+
+Composition is CPU-bound and blocking, and FEDOT may fan out to worker processes
+of its own, so a run gets its own process: that keeps the API responsive and
+makes cancellation a matter of killing a process tree.
+
+Progress is reported by appending JSON lines to ``events.jsonl`` in the run
+directory.  Per-generation events come from GOLEM's iteration callback, which
+fires every time a new population is recorded -- so the UI sees the evolution as
+it happens instead of waiting for the final ``OptHistory``.
+
+Run as::
+
+    python -m fedotweb.runs.worker <run_directory>
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any
+
+EVENTS_FILE = "events.jsonl"
+CONFIG_FILE = "config.json"
+RESULT_FILE = "result.json"
+HISTORY_FILE = "history.json"
+
+
+class EventWriter:
+    """Append-only JSONL sink shared with the parent process."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._started = time.monotonic()
+
+    def emit(self, kind: str, **payload: Any) -> None:
+        record = {
+            "kind": kind,
+            "elapsed": round(time.monotonic() - self._started, 3),
+            "payload": payload,
+        }
+        line = json.dumps(record, ensure_ascii=False, default=str)
+        # Opening per event keeps the file consistent for a reader that tails it
+        # while we write, which matters because the reader is a different process.
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+
+def _fitness_value(individual: Any) -> float | None:
+    """Fitness as a plain number, oriented so that *larger is better*.
+
+    GOLEM minimises internally and stores metrics negated for maximisation
+    objectives; ``Fitness.value`` gives the raw comparable number.
+    """
+    fitness = getattr(individual, "fitness", None)
+    if fitness is None:
+        return None
+    value = getattr(fitness, "value", None)
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number or number in (float("inf"), float("-inf")):  # NaN / inf
+        return None
+    return number
+
+
+def summarise_population(population: list[Any]) -> dict[str, Any]:
+    values = [v for v in (_fitness_value(ind) for ind in population) if v is not None]
+    summary: dict[str, Any] = {
+        "size": len(population),
+        "fitness": values,
+    }
+    if values:
+        summary["best_fitness"] = min(values)
+        summary["worst_fitness"] = max(values)
+        summary["mean_fitness"] = sum(values) / len(values)
+    return summary
+
+
+#: Keyword arguments the stdlib logger accepts; everything else must be dropped.
+_LOGGING_KWARGS = frozenset({"exc_info", "stack_info", "stacklevel", "extra"})
+
+
+def _patch_logger_kwargs() -> bool:
+    """Guard against an upstream logging mismatch killing a run.
+
+    The released FEDOT 0.7.5 calls ``log.warning(..., raise_if_test=True, exc=error)``
+    in several error paths -- invalid fitness during evaluation, cache read
+    failures. Neither GOLEM 0.4.1 (which that wheel pins) nor 0.4.2 accepts those
+    keywords, so they reach ``logging.Logger._log`` and raise ``TypeError``. A
+    composition then dies at the first pipeline that scores badly, which is a
+    normal event during evolution rather than a fatal one.
+
+    FEDOT master has removed those calls, so against master this wrapper never has
+    anything to strip. It stays as a safety net for anyone who installs the PyPI
+    release instead, and can be deleted once a release ships the fix.
+
+    ``raise_if_test`` asks to re-raise only inside FEDOT's own test session, so
+    dropping it yields exactly the warning that was intended.
+    """
+    try:
+        from golem.core.log import LoggerAdapter
+    except ImportError:
+        return False
+
+    if getattr(LoggerAdapter, "_fedotweb_kwargs_patched", False):
+        return False
+
+    original_log = LoggerAdapter.log
+
+    def log(self, level, msg, *args, **kwargs):
+        unsupported = set(kwargs) - _LOGGING_KWARGS
+        if unsupported:
+            details = ", ".join(f"{key}={kwargs.pop(key)!r}" for key in sorted(unsupported))
+            msg = f"{msg} [{details}]"
+        return original_log(self, level, msg, *args, **kwargs)
+
+    LoggerAdapter.log = log
+    LoggerAdapter._fedotweb_kwargs_patched = True
+    return True
+
+
+def _build_task(problem: str, config: dict[str, Any]):
+    from fedot.core.repository.tasks import TsForecastingParams
+
+    if problem == "ts_forecasting":
+        return TsForecastingParams(forecast_length=int(config.get("forecast_length") or 30))
+    return None
+
+
+def _compact_graph(individual: Any) -> dict[str, Any] | None:
+    """An individual's pipeline as bare structure: operations and their wiring."""
+    graph = getattr(individual, "graph", None)
+    nodes = getattr(graph, "nodes", None) if graph is not None else None
+    if not nodes:
+        return None
+
+    index_of = {id(node): f"n{position}" for position, node in enumerate(nodes)}
+    described_nodes = []
+    edges = []
+    for position, node in enumerate(nodes):
+        node_id = f"n{position}"
+        parameters = getattr(node, "parameters", None)
+        described_nodes.append(
+            {
+                "id": node_id,
+                "operation": str(getattr(node, "name", "") or ""),
+                "params": parameters if isinstance(parameters, dict) else {},
+            }
+        )
+        for parent in getattr(node, "nodes_from", None) or []:
+            parent_id = index_of.get(id(parent))
+            if parent_id is not None:
+                edges.append({"source": parent_id, "target": node_id})
+
+    return {"nodes": described_nodes, "edges": edges}
+
+
+def describe_lineage(population: list[Any]) -> list[dict[str, Any]]:
+    """Ancestry of one population, compact enough to stream every generation.
+
+    This is what lets the genealogy be drawn while the run is still going: the
+    saved ``OptHistory`` only exists once FEDOT finishes, so waiting for it would
+    mean no ancestry until the end.
+    """
+    from ..history.lineage import fitness_value, operations_of, operator_label
+
+    described: list[dict[str, Any]] = []
+    for individual in population:
+        entry: dict[str, Any] = {
+            "uid": str(individual.uid),
+            "fitness": fitness_value(individual),
+            "operations": operations_of(individual),
+            "native_generation": individual.native_generation,
+            # Structure and chosen parameters, so a node in the live genealogy can
+            # be opened the same way a finished one can. Operation defaults are
+            # left out; the client already has them from the catalogue.
+            "graph": _compact_graph(individual),
+        }
+
+        # Ancestry is sent for every individual; the graph builder decides which
+        # generation draws it, from where the individual first appears. Deciding
+        # here would mean comparing GOLEM's live generation counter against the
+        # value stored on the individual, and the two are offset by one.
+        try:
+            operators = list(individual.operators_from_prev_generation)
+        except ValueError:
+            # GOLEM raises when inheritance data is inconsistent.
+            operators = []
+        entry["operators"] = [
+            {
+                "uid": str(operator.uid),
+                "type": str(operator.type_),
+                "label": operator_label(operator),
+                "parents": [str(parent.uid) for parent in (operator.parent_individuals or ())],
+            }
+            for operator in operators
+        ]
+
+        described.append(entry)
+    return described
+
+
+def _make_progress_optimizer(events: EventWriter, state: dict[str, Any], run_dir: Path):
+    """An ``EvoGraphOptimizer`` that reports each generation and obeys live controls."""
+    from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
+
+    from .control import apply_controls, describe_effective, install_overrides, read_controls
+
+    def on_iteration(population, optimizer) -> None:
+        try:
+            generation = int(getattr(optimizer, "current_generation_num", 0))
+            members = list(population)
+            summary = summarise_population(members)
+
+            best_individuals = list(getattr(optimizer, "best_individuals", None) or [])
+            best = serialise_individual(best_individuals[0]) if best_individuals else None
+
+            state["last_generation"] = generation
+            events.emit("generation", generation=generation, best_pipeline=best, **summary)
+
+            # Ancestry goes in its own event: it is an order of magnitude larger
+            # than the summary, and a client that only wants the fitness curve
+            # should not have to parse it.
+            events.emit(
+                "population",
+                generation=generation,
+                individuals=describe_lineage(members),
+                best_uids=[str(individual.uid) for individual in best_individuals],
+            )
+        except Exception as exc:  # a reporting failure must never abort the run
+            events.emit("log", level="warning", message=f"progress callback failed: {exc}")
+
+        # Controls are applied between generations, never mid-flight.
+        try:
+            changes = apply_controls(optimizer, read_controls(run_dir))
+            if changes:
+                events.emit("control_applied", generation=generation, changes=changes)
+            # ``describe_effective`` already reports the generation.
+            events.emit("effective_params", **describe_effective(optimizer))
+        except Exception as exc:
+            events.emit("log", level="warning", message=f"could not apply controls: {exc}")
+
+    class ProgressReportingOptimizer(EvoGraphOptimizer):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            install_overrides(self)
+            self.set_iteration_callback(on_iteration)
+            # Anything already requested before the first generation applies now.
+            try:
+                apply_controls(self, read_controls(run_dir))
+            except Exception:
+                pass
+
+    return ProgressReportingOptimizer
+
+
+def serialise_individual(individual: Any) -> dict[str, Any] | None:
+    """Turn a GOLEM individual into the editor graph format."""
+    try:
+        from fedot.core.pipelines.adapters import PipelineAdapter
+
+        from ..pipelines.convert import pipeline_to_graph
+
+        graph = getattr(individual, "graph", None)
+        if graph is None:
+            return None
+        pipeline = PipelineAdapter().restore(graph)
+        described = pipeline_to_graph(pipeline)
+        described["fitness"] = _fitness_value(individual)
+        described["uid"] = str(getattr(individual, "uid", "") or "")
+        return described
+    except Exception:
+        return None
+
+
+def _load_dataset(config: dict[str, Any]):
+    """Load the configured CSV and split it into fit and holdout parts.
+
+    Metrics are reported on data the composer never saw, which is what makes the
+    number on the results screen mean something.  FEDOT's own
+    ``train_test_data_setup`` is used so that stratification (classification) and
+    temporal ordering (forecasting) are handled the way the framework expects.
+    """
+    from fedot.core.data.data import InputData
+    from fedot.core.data.data_split import train_test_data_setup
+    from fedot.core.repository.tasks import Task, TaskTypesEnum
+
+    path = config.get("dataset_path")
+    if not path:
+        raise ValueError("No dataset was supplied for the run")
+    dataset_path = Path(path)
+    if not dataset_path.exists():
+        raise ValueError(f"The dataset file is missing: {dataset_path}")
+
+    problem = config["problem"]
+    target = config.get("target") or "target"
+    task = Task(TaskTypesEnum(problem), _build_task(problem, config))
+
+    if problem == "ts_forecasting":
+        data = InputData.from_csv_time_series(
+            file_path=dataset_path, task=task, target_column=target
+        )
+        validation_blocks = int(config.get("validation_blocks") or 2)
+        train, test = train_test_data_setup(data, validation_blocks=validation_blocks)
+        return train, test, validation_blocks
+
+    data = InputData.from_csv(file_path=dataset_path, task=task, target_columns=target)
+    split_ratio = 1.0 - float(config.get("holdout_fraction") or 0.2)
+    # ``seed or 42`` would turn a legitimate seed of 0 into 42; the analysis
+    # worker mirrors this split, so both derive the seed the same way.
+    seed = config.get("seed")
+    train, test = train_test_data_setup(
+        data,
+        split_ratio=split_ratio,
+        shuffle=True,
+        stratify=problem == "classification",
+        random_seed=42 if seed is None else int(seed),
+    )
+    return train, test, None
+
+
+def run(run_dir: Path) -> int:
+    config: dict[str, Any] = json.loads((run_dir / CONFIG_FILE).read_text(encoding="utf-8"))
+    events = EventWriter(run_dir / EVENTS_FILE)
+    state: dict[str, Any] = {"last_generation": 0}
+
+    events.emit("status", status="starting", pid=os.getpid())
+
+    try:
+        _patch_logger_kwargs()
+
+        from fedot.api.main import Fedot
+
+        problem = config["problem"]
+        events.emit("status", status="loading_data", dataset=str(config.get("dataset_path")))
+        train_data, test_data, validation_blocks = _load_dataset(config)
+        events.emit(
+            "log",
+            level="info",
+            message=f"fit on {len(train_data.idx)} rows, holdout {len(test_data.idx)} rows",
+        )
+
+        composer_params: dict[str, Any] = {
+            "pop_size": int(config.get("pop_size") or 20),
+            "num_of_generations": int(config.get("num_of_generations") or 20),
+            "max_depth": int(config.get("max_depth") or 6),
+            "max_arity": int(config.get("max_arity") or 4),
+            "with_tuning": bool(config.get("with_tuning", True)),
+            "cv_folds": int(config.get("cv_folds") or 5),
+            "early_stopping_iterations": config.get("early_stopping_iterations"),
+        }
+        if config.get("metric"):
+            composer_params["metric"] = config["metric"]
+        if config.get("available_operations"):
+            composer_params["available_operations"] = list(config["available_operations"])
+        if config.get("initial_pipeline"):
+            from ..pipelines.convert import graph_to_pipeline
+
+            composer_params["initial_assumption"] = graph_to_pipeline(config["initial_pipeline"])
+
+        composer_params = {k: v for k, v in composer_params.items() if v is not None}
+
+        model = Fedot(
+            problem=problem,
+            timeout=float(config.get("timeout") or 5.0),
+            seed=config.get("seed"),
+            n_jobs=int(config.get("n_jobs") or 1),
+            logging_level=int(config.get("logging_level") or 20),
+            task_params=_build_task(problem, config),
+            preset=config.get("preset") or "auto",
+            optimizer=_make_progress_optimizer(events, state, run_dir),
+            **composer_params,
+        )
+
+        events.emit("status", status="composing")
+        model.fit(features=train_data)
+
+        if state["last_generation"] == 0:
+            # FEDOT skips evolution when the budget is too small for even one
+            # generation, and reports it only in the log; without this the UI
+            # would show an empty evolution chart and no reason for it.
+            events.emit(
+                "log",
+                level="warning",
+                message=(
+                    "Evolution was skipped: the time budget is too small for a generation "
+                    "on this dataset. The result is FEDOT's initial assumption"
+                    f"{' with tuned hyperparameters' if config.get('with_tuning', True) else ''}. "
+                    "Raise the time budget to let the composer search."
+                ),
+            )
+
+        events.emit("status", status="finalising")
+
+        result: dict[str, Any] = {"generations": state["last_generation"]}
+
+        from ..pipelines.convert import pipeline_to_graph
+
+        best_graph = pipeline_to_graph(model.current_pipeline)
+        result["best_pipeline"] = best_graph
+        (run_dir / "best_pipeline.json").write_text(
+            json.dumps(best_graph, ensure_ascii=False, allow_nan=False), encoding="utf-8"
+        )
+
+        # ``get_metrics`` scores whatever ``predict`` last ran on, so the holdout
+        # has to go through the pipeline before the metrics are asked for.
+        try:
+            if validation_blocks is not None:
+                model.predict(features=test_data, in_sample=True, validation_blocks=validation_blocks)
+                metrics = model.get_metrics(in_sample=True, validation_blocks=validation_blocks)
+            else:
+                model.predict(features=test_data)
+                metrics = model.get_metrics()
+            result["metrics"] = {
+                str(name): float(value)
+                for name, value in dict(metrics).items()
+                if isinstance(value, (int, float)) and value == value
+            }
+            result["metrics_source"] = "holdout"
+        except Exception as exc:
+            result["metrics"] = None
+            events.emit("log", level="warning", message=f"metrics unavailable: {exc}")
+
+        history = getattr(model, "history", None)
+        if history is not None:
+            try:
+                (run_dir / HISTORY_FILE).write_text(history.save(), encoding="utf-8")
+                result["generations"] = history.generations_count
+            except Exception as exc:
+                events.emit("log", level="warning", message=f"history not saved: {exc}")
+
+        (run_dir / RESULT_FILE).write_text(
+            json.dumps(result, ensure_ascii=False, allow_nan=False, default=str), encoding="utf-8"
+        )
+        events.emit("finished", **{k: v for k, v in result.items() if k != "best_pipeline"})
+        return 0
+
+    except KeyboardInterrupt:
+        events.emit("cancelled", message="Run cancelled")
+        return 130
+    except Exception as exc:
+        events.emit("error", message=str(exc), traceback=traceback.format_exc())
+        return 1
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: python -m fedotweb.runs.worker <run_directory>", file=sys.stderr)
+        return 2
+    return run(Path(sys.argv[1]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/fedotweb/schemas.py
+++ b/backend/fedotweb/schemas.py
@@ -1,0 +1,423 @@
+"""Request and response models for the HTTP API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+ParameterType = Literal["continuous", "discrete", "categorical", "nested", "boolean", "free"]
+ValueType = Literal["number", "integer", "string", "boolean", "array", "object"]
+
+
+class NestedVariant(BaseModel):
+    label: str
+    fixed: dict[str, Any] = Field(default_factory=dict)
+    options: dict[str, list[Any]] = Field(default_factory=dict)
+
+
+class ParameterSchema(BaseModel):
+    """How a single hyperparameter should be presented and validated."""
+
+    name: str
+    type: ParameterType
+    value_type: ValueType
+    #: ``True`` when FEDOT's tuner explores this parameter.
+    tunable: bool
+    #: Name of the underlying hyperopt distribution, when there is one.
+    distribution: str | None = None
+    #: Whether the sampling scope is best traversed logarithmically.
+    log_scale: bool = False
+    default: Any = None
+    minimum: float | None = None
+    maximum: float | None = None
+    choices: list[Any] | None = None
+    nested_variants: list[NestedVariant] | None = None
+
+
+class OperationSummary(BaseModel):
+    id: str
+    kind: str
+    group: str
+    family: str | None = None
+    description: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    presets: list[str] = Field(default_factory=list)
+    tasks: list[str] = Field(default_factory=list)
+    input_types: list[str] = Field(default_factory=list)
+    output_types: list[str] = Field(default_factory=list)
+    allowed_positions: list[str] = Field(default_factory=list)
+    is_default: bool = True
+
+
+class OperationDetail(OperationSummary):
+    parameters: list[ParameterSchema] = Field(default_factory=list)
+    defaults: dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphNode(BaseModel):
+    id: str
+    operation: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
+    # Fields the backend fills in when describing a pipeline; accepted but ignored
+    # on the way in so the UI can post back exactly what it received.
+    label: str | None = None
+    kind: str | None = None
+    group: str | None = None
+    description: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    defaults: dict[str, Any] = Field(default_factory=dict)
+    parents: list[str] = Field(default_factory=list)
+    children: list[str] = Field(default_factory=list)
+    is_primary: bool = False
+    is_root: bool = False
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def _coerce_id(cls, value: Any) -> str:
+        # The legacy frontend used integer node ids.
+        return str(value)
+
+
+class GraphEdge(BaseModel):
+    source: str
+    target: str
+    id: str | None = None
+
+    @field_validator("source", "target", mode="before")
+    @classmethod
+    def _coerce_endpoint(cls, value: Any) -> str:
+        return str(value)
+
+
+class PipelineGraph(BaseModel):
+    uid: str = ""
+    nodes: list[GraphNode] = Field(default_factory=list)
+    edges: list[GraphEdge] = Field(default_factory=list)
+    depth: int = 0
+    length: int = 0
+
+
+class PipelineRecord(BaseModel):
+    uid: str
+    name: str
+    task: str | None = None
+    origin: str | None = None
+    run_uid: str | None = None
+    created_at: str
+    updated_at: str
+    length: int = 0
+    depth: int = 0
+    graph: PipelineGraph | None = None
+
+
+class SavePipelineRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    task: str | None = None
+    graph: PipelineGraph
+    uid: str | None = None
+
+
+class ValidatePipelineRequest(BaseModel):
+    graph: PipelineGraph
+    task: str | None = None
+
+
+class ValidationResult(BaseModel):
+    is_valid: bool
+    problems: list[str] = Field(default_factory=list)
+    depth: int = 0
+    length: int = 0
+
+
+class DatasetColumn(BaseModel):
+    name: str
+    index: int
+    type: str
+    distinct_sample: int = 0
+    missing_sample: int = 0
+    examples: list[str] = Field(default_factory=list)
+
+
+class DatasetRecord(BaseModel):
+    uid: str
+    name: str
+    filename: str
+    task: str | None = None
+    target: str | None = None
+    n_rows: int | None = None
+    n_columns: int | None = None
+    columns: list[DatasetColumn] = Field(default_factory=list)
+    created_at: str
+
+
+class DatasetUploadResult(DatasetRecord):
+    preview: list[dict[str, Any]] = Field(default_factory=list)
+    suggested_target: str | None = None
+
+
+class RunConfig(BaseModel):
+    """Everything the run form can set, mapped onto FEDOT's API parameters."""
+
+    problem: Literal["classification", "regression", "ts_forecasting"]
+    dataset_uid: str
+    target: str | None = None
+
+    timeout: float = Field(default=5.0, gt=0, description="Composition budget in minutes")
+    preset: str = "auto"
+    metric: str | None = None
+    seed: int | None = None
+    n_jobs: int = Field(default=1, ge=-1)
+    cv_folds: int = Field(default=5, ge=2, le=20)
+
+    pop_size: int = Field(default=20, ge=2, le=200)
+    num_of_generations: int = Field(default=20, ge=1, le=500)
+    max_depth: int = Field(default=6, ge=1, le=20)
+    max_arity: int = Field(default=4, ge=1, le=20)
+    with_tuning: bool = True
+    early_stopping_iterations: int | None = Field(default=None, ge=1)
+
+    available_operations: list[str] | None = None
+    forecast_length: int = Field(default=30, ge=1)
+    initial_pipeline: PipelineGraph | None = None
+
+    logging_level: int = 20
+
+
+class StartRunRequest(BaseModel):
+    name: str | None = None
+    config: RunConfig
+
+
+class RunRecord(BaseModel):
+    uid: str
+    name: str
+    dataset_uid: str | None = None
+    config: dict[str, Any] = Field(default_factory=dict)
+    status: str
+    error: str | None = None
+    metrics: dict[str, float] | None = None
+    best_pipeline: str | None = None
+    created_at: str
+    started_at: str | None = None
+    finished_at: str | None = None
+
+
+class EvolutionControls(BaseModel):
+    """Knobs that can be turned while the evolution is running.
+
+    `None` on a field means "leave GOLEM's own policy in charge"; setting a value
+    pins it until it is cleared again.
+    """
+
+    pop_size: int | None = Field(default=None, ge=2, le=500)
+    num_of_generations: int | None = Field(default=None, ge=1, le=10_000)
+    timeout_minutes: float | None = Field(default=None, gt=0)
+    mutation_prob: float | None = Field(default=None, ge=0.0, le=1.0)
+    crossover_prob: float | None = Field(default=None, ge=0.0, le=1.0)
+    #: Stop after the current generation, keeping the best pipeline found so far.
+    finish_now: bool = False
+
+
+class EffectiveParams(BaseModel):
+    """What the optimiser is actually using right now."""
+
+    generation: int = 0
+    pop_size: int | None = None
+    mutation_prob: float | None = None
+    crossover_prob: float | None = None
+    num_of_generations: int | None = None
+    timeout_minutes: float | None = None
+    max_depth: int | None = None
+
+
+class RunControlState(BaseModel):
+    requested: EvolutionControls = Field(default_factory=EvolutionControls)
+    effective: EffectiveParams | None = None
+    #: False once the run ends; the controls then have nothing to act on.
+    can_control: bool = False
+    #: Most recent changes the worker reported applying.
+    applied: list[str] = Field(default_factory=list)
+
+
+class RunEvent(BaseModel):
+    id: int
+    created_at: str
+    kind: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class GenerationPoint(BaseModel):
+    """One point on the evolution chart."""
+
+    generation: int
+    size: int
+    best_fitness: float | None = None
+    mean_fitness: float | None = None
+    worst_fitness: float | None = None
+    elapsed: float | None = None
+
+
+class RunProgress(BaseModel):
+    run: RunRecord
+    generations: list[GenerationPoint] = Field(default_factory=list)
+    best_pipeline: PipelineGraph | None = None
+    last_event_id: int = 0
+
+
+class LineageNode(BaseModel):
+    """One node of the evolution genealogy.
+
+    Individuals and operators share the payload; `kind` says which fields apply.
+    """
+
+    id: str
+    kind: Literal["individual", "operator"]
+    uid: str
+    generation: int
+    #: Individuals sit on even layers, the operators that produced them on odd ones.
+    layer: int
+    on_winning_path: bool = False
+
+    # individual
+    index: int | None = None
+    fitness: float | None = None
+    operations: list[str] = Field(default_factory=list)
+    length: int | None = None
+    native_generation: int | None = None
+    is_best_in_generation: bool = False
+    is_final_choice: bool = False
+    #: While a run is going there is no final choice, only a leader so far.
+    is_current_best: bool = False
+
+    # operator
+    operator_type: str | None = None
+    label: str | None = None
+
+
+class LineageEdge(BaseModel):
+    id: str
+    source: str
+    target: str
+    #: `survival`, `produces`, `chain`, or the operator type that created it.
+    kind: str
+
+
+class GenerationInfo(BaseModel):
+    """One stored generation, which may be evolution or bookkeeping.
+
+    GOLEM records the seed populations and the final choice alongside the real
+    generations, so `is_evolutionary` separates the two.
+    """
+
+    index: int
+    label: str
+    raw_label: str = ""
+    size: int = 0
+    is_evolutionary: bool = True
+
+
+class LineageGraph(BaseModel):
+    nodes: list[LineageNode] = Field(default_factory=list)
+    edges: list[LineageEdge] = Field(default_factory=list)
+    #: Every stored generation, including the seed and result pseudo-generations.
+    generations: int = 0
+    #: How many of those were actual rounds of evolution.
+    evolution_generations: int = 0
+    generation_meta: list[GenerationInfo] = Field(default_factory=list)
+    #: True when only the ancestry of the final choice is included.
+    only_winning_path: bool = True
+    #: True when the individual cap was hit and the graph is incomplete.
+    truncated: bool = False
+    metric_names: list[str] = Field(default_factory=list)
+    #: `history` for a finished run, `live` when assembled from progress events.
+    source: Literal["history", "live"] = "history"
+    is_live: bool = False
+
+
+class IndividualPipeline(PipelineGraph):
+    """The pipeline behind one node of the genealogy."""
+
+    fitness: float | None = None
+    generation: int | None = None
+
+
+class StartAnalysisRequest(BaseModel):
+    """Ask for an on-demand analysis of one pipeline from a run."""
+
+    kind: Literal["objective", "sensitivity"]
+    #: Which pipeline to analyse. Defaults to the run's best.
+    pipeline_uid: str | None = None
+    #: Or an individual from the run's genealogy.
+    individual_uid: str | None = None
+    #: Sensitivity only: how many replacement operations to try per node.
+    replacements: int = Field(default=2, ge=1, le=10)
+    analyse_edges: bool = True
+
+
+class AnalysisRecord(BaseModel):
+    uid: str
+    run_uid: str
+    kind: str
+    pipeline_uid: str | None = None
+    options: dict[str, Any] = Field(default_factory=dict)
+    status: str
+    error: str | None = None
+    #: Shape depends on `kind`; see the analysis worker.
+    result: dict[str, Any] | None = None
+    created_at: str
+    finished_at: str | None = None
+
+
+class PreprocessingStep(BaseModel):
+    id: str
+    title: str
+    detail: str
+    columns: list[int] = Field(default_factory=list)
+    applied: bool = False
+
+
+class PreprocessingReport(BaseModel):
+    """What FEDOT's obligatory preprocessing does to a dataset."""
+
+    problem: str
+    target: str
+    rows: dict[str, int] = Field(default_factory=dict)
+    columns: dict[str, int] = Field(default_factory=dict)
+    #: Per-column counts of the types actually found in the raw file, in file order.
+    source_types: list[dict[str, Any]] = Field(default_factory=list)
+    #: Type each file column reaches the pipeline as; None where it was dropped.
+    final_types: list[str | None] = Field(default_factory=list)
+    target_type: str | None = None
+    steps: list[PreprocessingStep] = Field(default_factory=list)
+    note: str = ""
+
+
+class TaskInfo(BaseModel):
+    id: str
+    label: str
+
+
+class MetricInfo(BaseModel):
+    id: str
+    label: str
+    tasks: list[str] = Field(default_factory=list)
+
+
+class PresetInfo(BaseModel):
+    id: str
+    label: str
+    description: str
+
+
+class CapabilitiesResponse(BaseModel):
+    """Everything the run-configuration form needs in one request."""
+
+    fedot_version: str
+    golem_version: str | None = None
+    tasks: list[TaskInfo] = Field(default_factory=list)
+    metrics: list[MetricInfo] = Field(default_factory=list)
+    presets: list[PresetInfo] = Field(default_factory=list)
+    max_run_timeout_minutes: float = 240.0
+    max_concurrent_runs: int = 2

--- a/backend/fedotweb/schemas.py
+++ b/backend/fedotweb/schemas.py
@@ -363,6 +363,49 @@ class StartAnalysisRequest(BaseModel):
     analyse_edges: bool = True
 
 
+class ActiveEvaluation(BaseModel):
+    """One pipeline being fitted right now."""
+
+    ops: list[str] = Field(default_factory=list)
+    #: Zero-based index of the fold currently being fitted, if known.
+    fold: int | None = None
+    #: The operation whose fit is in progress, if any.
+    node: str | None = None
+    seconds: float = 0
+
+
+class FinishedEvaluation(BaseModel):
+    ops: list[str] = Field(default_factory=list)
+    seconds: float | None = None
+    fitness: float | None = None
+    failed: bool = False
+    error: str | None = None
+    finished: float | None = None
+
+
+class PreparationFit(BaseModel):
+    """A node fit outside evolution: the initial assumption or the final refit."""
+
+    node: str | None = None
+    seconds: float = 0
+
+
+class EvaluationTotals(BaseModel):
+    done: int = 0
+    failed: int = 0
+    active: int = 0
+    mean_seconds: float | None = None
+
+
+class EvaluationState(BaseModel):
+    """What the evaluator is doing right now, assembled from the run's trace."""
+
+    active: list[ActiveEvaluation] = Field(default_factory=list)
+    preparing: PreparationFit | None = None
+    recent: list[FinishedEvaluation] = Field(default_factory=list)
+    totals: EvaluationTotals = Field(default_factory=EvaluationTotals)
+
+
 class StandaloneAnalysisRequest(BaseModel):
     """Ask for an analysis of a pipeline that is not tied to a run.
 

--- a/backend/fedotweb/schemas.py
+++ b/backend/fedotweb/schemas.py
@@ -257,6 +257,10 @@ class GenerationPoint(BaseModel):
     mean_fitness: float | None = None
     worst_fitness: float | None = None
     elapsed: float | None = None
+    #: Identity of the generation's best individual, so the chart can mark the
+    #: generations where the leader actually changed.
+    best_uid: str | None = None
+    best_operations: list[str] = Field(default_factory=list)
 
 
 class RunProgress(BaseModel):

--- a/backend/fedotweb/schemas.py
+++ b/backend/fedotweb/schemas.py
@@ -332,6 +332,9 @@ class LineageGraph(BaseModel):
     generation_meta: list[GenerationInfo] = Field(default_factory=list)
     #: True when only the ancestry of the final choice is included.
     only_winning_path: bool = True
+    #: In the winning-path view, how many trailing generations were dropped
+    #: because the best fitness never improved in them.
+    hidden_plateau_generations: int = 0
     #: True when the individual cap was hit and the graph is incomplete.
     truncated: bool = False
     metric_names: list[str] = Field(default_factory=list)
@@ -355,6 +358,28 @@ class StartAnalysisRequest(BaseModel):
     pipeline_uid: str | None = None
     #: Or an individual from the run's genealogy.
     individual_uid: str | None = None
+    #: Sensitivity only: how many replacement operations to try per node.
+    replacements: int = Field(default=2, ge=1, le=10)
+    analyse_edges: bool = True
+
+
+class StandaloneAnalysisRequest(BaseModel):
+    """Ask for an analysis of a pipeline that is not tied to a run.
+
+    The editor uses this: the pipeline is fitted on the chosen dataset first,
+    so the analysis pays for those fits with no run to borrow them from.
+    """
+
+    kind: Literal["objective", "sensitivity"]
+    graph: PipelineGraph
+    dataset_uid: str
+    #: Defaults to the dataset's own target column.
+    target: str | None = None
+    #: Defaults to the dataset's task.
+    problem: str | None = None
+    metric: str | None = None
+    cv_folds: int = Field(default=5, ge=2, le=10)
+    seed: int | None = None
     #: Sensitivity only: how many replacement operations to try per node.
     replacements: int = Field(default=2, ge=1, le=10)
     analyse_edges: bool = True

--- a/backend/fedotweb/settings.py
+++ b/backend/fedotweb/settings.py
@@ -1,0 +1,74 @@
+"""Runtime configuration.
+
+The legacy backend refused to start without a reachable MongoDB.  Here SQLite is
+the default so that ``pip install`` followed by ``fedot-web`` is enough to get a
+working instance; Mongo can still be switched on for large evolution histories by
+setting ``FEDOTWEB_MONGO_URI``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def _default_workspace() -> Path:
+    return Path.home() / ".fedot-web"
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="FEDOTWEB_", env_file=".env", extra="ignore")
+
+    #: Where uploaded datasets, saved pipelines and run artefacts live.
+    workspace: Path = _default_workspace()
+
+    #: Optional MongoDB connection string.  When unset, SQLite is used.
+    mongo_uri: str | None = None
+    mongo_db: str = "fedot_web"
+
+    host: str = "127.0.0.1"
+    port: int = 8000
+    reload: bool = False
+
+    #: Origins allowed to call the API.  The Vite dev server runs on 5173.
+    cors_origins: list[str] = ["http://localhost:5173", "http://127.0.0.1:5173"]
+
+    #: Hard ceiling on an AutoML run, regardless of what the user asks for.
+    max_run_timeout_minutes: float = 240.0
+
+    #: Largest dataset accepted through the upload endpoint.
+    max_upload_mb: float = 256.0
+
+    #: How many AutoML runs may execute at the same time.
+    max_concurrent_runs: int = 2
+
+    #: Directory holding the built frontend; served at ``/`` when present.
+    static_dir: Path | None = None
+
+    @property
+    def database_path(self) -> Path:
+        return self.workspace / "fedot-web.sqlite"
+
+    @property
+    def datasets_dir(self) -> Path:
+        return self.workspace / "datasets"
+
+    @property
+    def runs_dir(self) -> Path:
+        return self.workspace / "runs"
+
+    def ensure_directories(self) -> None:
+        for directory in (self.workspace, self.datasets_dir, self.runs_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+        _settings.ensure_directories()
+    return _settings

--- a/backend/fedotweb/storage/__init__.py
+++ b/backend/fedotweb/storage/__init__.py
@@ -1,0 +1,3 @@
+﻿from .sqlite import Store, new_uid, utcnow
+
+__all__ = ["Store", "new_uid", "utcnow"]

--- a/backend/fedotweb/storage/sqlite.py
+++ b/backend/fedotweb/storage/sqlite.py
@@ -1,0 +1,419 @@
+"""SQLite-backed persistence.
+
+The data here is document-shaped (pipeline graphs, run configurations, evolution
+histories), so it is stored as JSON in a handful of tables rather than through an
+ORM.  A connection is opened per operation -- with WAL enabled that is cheap and
+sidesteps the thread-affinity rules SQLite imposes on connections shared between
+FastAPI's worker threads.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS pipelines (
+    uid          TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    task         TEXT,
+    graph        TEXT NOT NULL,
+    origin       TEXT,
+    run_uid      TEXT,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS datasets (
+    uid          TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    filename     TEXT NOT NULL,
+    task         TEXT,
+    target       TEXT,
+    n_rows       INTEGER,
+    n_columns    INTEGER,
+    columns      TEXT NOT NULL,
+    created_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS runs (
+    uid          TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    dataset_uid  TEXT,
+    config       TEXT NOT NULL,
+    status       TEXT NOT NULL,
+    error        TEXT,
+    metrics      TEXT,
+    best_pipeline TEXT,
+    created_at   TEXT NOT NULL,
+    started_at   TEXT,
+    finished_at  TEXT
+);
+
+CREATE TABLE IF NOT EXISTS run_events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_uid      TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    payload      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS analyses (
+    uid          TEXT PRIMARY KEY,
+    run_uid      TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    pipeline_uid TEXT,
+    options      TEXT NOT NULL,
+    status       TEXT NOT NULL,
+    error        TEXT,
+    result       TEXT,
+    created_at   TEXT NOT NULL,
+    finished_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_events_run ON run_events (run_uid, id);
+CREATE INDEX IF NOT EXISTS idx_pipelines_run ON pipelines (run_uid);
+CREATE INDEX IF NOT EXISTS idx_analyses_run ON analyses (run_uid, datetime(created_at));
+"""
+
+
+def utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def new_uid() -> str:
+    return uuid.uuid4().hex
+
+
+class Store:
+    """Thin persistence layer over SQLite."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.executescript(SCHEMA)
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self._path, timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA foreign_keys=ON")
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    # ---------------------------------------------------------------- pipelines
+
+    def save_pipeline(
+        self,
+        *,
+        graph: dict[str, Any],
+        name: str,
+        task: str | None = None,
+        origin: str = "editor",
+        run_uid: str | None = None,
+        uid: str | None = None,
+    ) -> str:
+        uid = uid or new_uid()
+        now = utcnow()
+        payload = json.dumps(graph, ensure_ascii=False, allow_nan=False)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO pipelines (uid, name, task, graph, origin, run_uid, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(uid) DO UPDATE SET
+                    name = excluded.name,
+                    task = excluded.task,
+                    graph = excluded.graph,
+                    updated_at = excluded.updated_at
+                """,
+                (uid, name, task, payload, origin, run_uid, now, now),
+            )
+        return uid
+
+    def get_pipeline(self, uid: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM pipelines WHERE uid = ?", (uid,)).fetchone()
+        return self._pipeline_row(row) if row else None
+
+    def list_pipelines(self, *, run_uid: str | None = None, limit: int = 200) -> list[dict[str, Any]]:
+        query = "SELECT * FROM pipelines"
+        params: list[Any] = []
+        if run_uid:
+            query += " WHERE run_uid = ?"
+            params.append(run_uid)
+        query += " ORDER BY datetime(updated_at) DESC LIMIT ?"
+        params.append(limit)
+        with self._connect() as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [self._pipeline_row(row) for row in rows]
+
+    def delete_pipeline(self, uid: str) -> bool:
+        with self._connect() as conn:
+            cursor = conn.execute("DELETE FROM pipelines WHERE uid = ?", (uid,))
+        return cursor.rowcount > 0
+
+    @staticmethod
+    def _pipeline_row(row: sqlite3.Row) -> dict[str, Any]:
+        graph = json.loads(row["graph"])
+        return {
+            "uid": row["uid"],
+            "name": row["name"],
+            "task": row["task"],
+            "origin": row["origin"],
+            "run_uid": row["run_uid"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "graph": graph,
+            "length": graph.get("length", len(graph.get("nodes", []))),
+            "depth": graph.get("depth", 0),
+        }
+
+    # ----------------------------------------------------------------- datasets
+
+    def save_dataset(self, record: dict[str, Any]) -> str:
+        uid = record.get("uid") or new_uid()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO datasets
+                    (uid, name, filename, task, target, n_rows, n_columns, columns, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    uid,
+                    record["name"],
+                    record["filename"],
+                    record.get("task"),
+                    record.get("target"),
+                    record.get("n_rows"),
+                    record.get("n_columns"),
+                    json.dumps(record.get("columns", []), ensure_ascii=False),
+                    record.get("created_at") or utcnow(),
+                ),
+            )
+        return uid
+
+    def get_dataset(self, uid: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM datasets WHERE uid = ?", (uid,)).fetchone()
+        return self._dataset_row(row) if row else None
+
+    def list_datasets(self) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute("SELECT * FROM datasets ORDER BY datetime(created_at) DESC").fetchall()
+        return [self._dataset_row(row) for row in rows]
+
+    def delete_dataset(self, uid: str) -> bool:
+        with self._connect() as conn:
+            cursor = conn.execute("DELETE FROM datasets WHERE uid = ?", (uid,))
+        return cursor.rowcount > 0
+
+    @staticmethod
+    def _dataset_row(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "uid": row["uid"],
+            "name": row["name"],
+            "filename": row["filename"],
+            "task": row["task"],
+            "target": row["target"],
+            "n_rows": row["n_rows"],
+            "n_columns": row["n_columns"],
+            "columns": json.loads(row["columns"]),
+            "created_at": row["created_at"],
+        }
+
+    # --------------------------------------------------------------------- runs
+
+    def create_run(self, *, name: str, dataset_uid: str | None, config: dict[str, Any]) -> str:
+        uid = new_uid()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO runs (uid, name, dataset_uid, config, status, created_at)
+                VALUES (?, ?, ?, ?, 'pending', ?)
+                """,
+                (uid, name, dataset_uid, json.dumps(config, ensure_ascii=False), utcnow()),
+            )
+        return uid
+
+    def update_run(self, uid: str, **fields: Any) -> None:
+        if not fields:
+            return
+        allowed = {"status", "error", "metrics", "best_pipeline", "started_at", "finished_at"}
+        assignments, params = [], []
+        for key, value in fields.items():
+            if key not in allowed:
+                raise KeyError(f"Cannot update run field: {key}")
+            assignments.append(f"{key} = ?")
+            params.append(json.dumps(value, ensure_ascii=False) if isinstance(value, (dict, list)) else value)
+        params.append(uid)
+        with self._connect() as conn:
+            conn.execute(f"UPDATE runs SET {', '.join(assignments)} WHERE uid = ?", params)
+
+    def get_run(self, uid: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM runs WHERE uid = ?", (uid,)).fetchone()
+        return self._run_row(row) if row else None
+
+    def list_runs(self, limit: int = 100) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM runs ORDER BY datetime(created_at) DESC LIMIT ?", (limit,)
+            ).fetchall()
+        return [self._run_row(row) for row in rows]
+
+    def delete_run(self, uid: str) -> bool:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM run_events WHERE run_uid = ?", (uid,))
+            conn.execute("DELETE FROM pipelines WHERE run_uid = ?", (uid,))
+            conn.execute("DELETE FROM analyses WHERE run_uid = ?", (uid,))
+            cursor = conn.execute("DELETE FROM runs WHERE uid = ?", (uid,))
+        return cursor.rowcount > 0
+
+    @staticmethod
+    def _run_row(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "uid": row["uid"],
+            "name": row["name"],
+            "dataset_uid": row["dataset_uid"],
+            "config": json.loads(row["config"]),
+            "status": row["status"],
+            "error": row["error"],
+            "metrics": json.loads(row["metrics"]) if row["metrics"] else None,
+            "best_pipeline": row["best_pipeline"],
+            "created_at": row["created_at"],
+            "started_at": row["started_at"],
+            "finished_at": row["finished_at"],
+        }
+
+    # ----------------------------------------------------------------- analyses
+
+    def create_analysis(
+        self, *, run_uid: str, kind: str, pipeline_uid: str | None, options: dict[str, Any]
+    ) -> str:
+        uid = new_uid()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO analyses (uid, run_uid, kind, pipeline_uid, options, status, created_at)
+                VALUES (?, ?, ?, ?, ?, 'running', ?)
+                """,
+                (uid, run_uid, kind, pipeline_uid, json.dumps(options, ensure_ascii=False), utcnow()),
+            )
+        return uid
+
+    def finish_analysis(
+        self, uid: str, *, result: dict[str, Any] | None = None, error: str | None = None
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE analyses SET status = ?, result = ?, error = ?, finished_at = ? WHERE uid = ?",
+                (
+                    "failed" if error else "finished",
+                    json.dumps(result, ensure_ascii=False, default=str) if result else None,
+                    error,
+                    utcnow(),
+                    uid,
+                ),
+            )
+
+    def fail_running_analyses(self, reason: str) -> int:
+        """Mark every analysis still 'running' as failed.
+
+        Called at startup: an analysis worker is owned by the server process, so
+        anything still marked running after a restart is definitionally dead --
+        and would otherwise be polled by the UI forever.
+        """
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE analyses SET status = 'failed', error = ?, finished_at = ? "
+                "WHERE status = 'running'",
+                (reason, utcnow()),
+            )
+        return cursor.rowcount
+
+    def get_analysis(self, uid: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM analyses WHERE uid = ?", (uid,)).fetchone()
+        return self._analysis_row(row) if row else None
+
+    def list_analyses(self, run_uid: str) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM analyses WHERE run_uid = ? ORDER BY datetime(created_at) DESC",
+                (run_uid,),
+            ).fetchall()
+        return [self._analysis_row(row) for row in rows]
+
+    @staticmethod
+    def _analysis_row(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "uid": row["uid"],
+            "run_uid": row["run_uid"],
+            "kind": row["kind"],
+            "pipeline_uid": row["pipeline_uid"],
+            "options": json.loads(row["options"]),
+            "status": row["status"],
+            "error": row["error"],
+            "result": json.loads(row["result"]) if row["result"] else None,
+            "created_at": row["created_at"],
+            "finished_at": row["finished_at"],
+        }
+
+    # --------------------------------------------------------------- run events
+
+    def append_event(self, run_uid: str, kind: str, payload: dict[str, Any]) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "INSERT INTO run_events (run_uid, created_at, kind, payload) VALUES (?, ?, ?, ?)",
+                (run_uid, utcnow(), kind, json.dumps(payload, ensure_ascii=False, default=str)),
+            )
+        return int(cursor.lastrowid)
+
+    def list_events(
+        self,
+        run_uid: str,
+        *,
+        after_id: int = 0,
+        kinds: list[str] | None = None,
+        limit: int = 5000,
+    ) -> list[dict[str, Any]]:
+        """Events for a run, oldest first.
+
+        ``kinds`` narrows the query in SQL. Population events carry whole
+        pipelines and dwarf everything else, so a caller that only needs the
+        fitness curve should not have to fetch and parse them.
+        """
+        query = "SELECT * FROM run_events WHERE run_uid = ? AND id > ?"
+        params: list[Any] = [run_uid, after_id]
+        if kinds:
+            query += f" AND kind IN ({', '.join('?' * len(kinds))})"
+            params.extend(kinds)
+        query += " ORDER BY id LIMIT ?"
+        params.append(limit)
+        with self._connect() as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [
+            {
+                "id": row["id"],
+                "created_at": row["created_at"],
+                "kind": row["kind"],
+                "payload": json.loads(row["payload"]),
+            }
+            for row in rows
+        ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,54 @@
+[project]
+name = "fedot-web-backend"
+version = "2.0.0"
+description = "Modern web GUI for the FEDOT AutoML framework and the GOLEM optimiser"
+# Pydantic evaluates the PEP 604 annotations in `schemas.py` at runtime, so 3.10
+# is the floor even though `from __future__ import annotations` is used.
+requires-python = ">=3.10"
+license = { text = "BSD-3-Clause" }
+
+dependencies = [
+    # The 0.7.5 release passes unsupported keywords to the logger and kills a run
+    # on the first badly-scoring pipeline; install FEDOT from master. See the
+    # README section "Why FEDOT is installed from master".
+    "fedot>=0.7.5",
+    "thegolem>=0.4.2",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.32.0",
+    "pydantic>=2.9.0",
+    "pydantic-settings>=2.6.0",
+    "python-multipart>=0.0.12",
+    "aiofiles>=24.1.0",
+]
+
+[project.optional-dependencies]
+mongo = ["pymongo>=4.9.0"]
+dev = [
+    "pytest>=8.3.0",
+    "pytest-asyncio>=0.24.0",
+    "httpx>=0.27.0",
+    "ruff>=0.7.0",
+]
+
+[project.scripts]
+fedot-web = "fedotweb.__main__:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["fedotweb*"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["B008"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+filterwarnings = ["ignore::DeprecationWarning"]

--- a/backend/tests/test_analysis.py
+++ b/backend/tests/test_analysis.py
@@ -1,0 +1,246 @@
+"""The analyses you ask for: where a score came from, and what it rests on."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("FEDOTWEB_WORKSPACE", str(tmp_path / "workspace"))
+
+    import fedotweb.settings as settings_module
+
+    settings_module._settings = None  # noqa: SLF001 - reset the cached singleton
+
+    from fedotweb.main import create_app
+
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def dataset_uid(client: TestClient, tmp_path: Path) -> str:
+    """A table with a deliberately awkward column, to give preprocessing work."""
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(5)
+    size = 300
+    frame = pd.DataFrame(
+        {
+            "x1": rng.normal(size=size),
+            # Few distinct integers: FEDOT should read this as a category.
+            "few_values": rng.integers(0, 3, size=size),
+            # One repeated value carries nothing.
+            "constant": np.ones(size),
+            "target": rng.integers(0, 2, size=size),
+        }
+    )
+    frame.loc[frame.index[:10], "x1"] = np.nan
+
+    path = tmp_path / "messy.csv"
+    frame.to_csv(path, index=False)
+
+    with path.open("rb") as handle:
+        response = client.post(
+            "/api/datasets",
+            files={"file": ("messy.csv", handle, "text/csv")},
+            data={"task": "classification", "target": "target"},
+        )
+    assert response.status_code == 201, response.text
+    return response.json()["uid"]
+
+
+@pytest.fixture()
+def finished_run(client: TestClient, dataset_uid: str) -> str:
+    response = client.post(
+        "/api/runs",
+        json={
+            "name": "for analysis",
+            "config": {
+                "problem": "classification",
+                "dataset_uid": dataset_uid,
+                "target": "target",
+                "timeout": 0.6,
+                "preset": "fast_train",
+                "pop_size": 3,
+                "num_of_generations": 2,
+                "with_tuning": False,
+                "cv_folds": 3,
+                "n_jobs": 1,
+                "seed": 4,
+                "metric": "roc_auc",
+            },
+        },
+    )
+    assert response.status_code == 202, response.text
+    run_uid = response.json()["uid"]
+
+    deadline = time.monotonic() + 420
+    while time.monotonic() < deadline:
+        record = client.get(f"/api/runs/{run_uid}").json()
+        if record["status"] not in {"running", "pending"}:
+            break
+        time.sleep(2.0)
+    assert record["status"] == "finished", record.get("error")
+    assert record["best_pipeline"]
+    return run_uid
+
+
+def await_analysis(client: TestClient, analysis_uid: str, deadline: float = 900) -> dict:
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        record = client.get(f"/api/analyses/{analysis_uid}").json()
+        if record["status"] != "running":
+            return record
+        time.sleep(2.0)
+    pytest.fail("the analysis never finished")
+
+
+# ------------------------------------------------------------------ preprocessing
+
+
+def test_preprocessing_report_explains_what_fedot_changes(
+    client: TestClient, dataset_uid: str
+) -> None:
+    response = client.get(f"/api/datasets/{dataset_uid}/preprocessing?task=classification")
+    assert response.status_code == 200, response.text
+    report = response.json()
+
+    assert report["rows"]["before"] == 300
+    assert report["source_types"], "no per-column information"
+
+    # Everything is reported against the uploaded file's columns: one row and one
+    # final type per file column, None where a column did not survive.
+    assert len(report["final_types"]) == report["columns"]["before"]
+    survivors = [t for t in report["final_types"] if t is not None]
+    assert len(survivors) == report["columns"]["after"]
+    assert [row["column"] for row in report["source_types"]] == list(
+        range(report["columns"]["before"])
+    )
+
+    steps = {step["id"]: step for step in report["steps"]}
+    assert {"empty_columns", "type_conflicts", "numeric_to_categorical"} <= set(steps)
+    for step in report["steps"]:
+        for column in step["columns"]:
+            assert 0 <= column < report["columns"]["before"], step
+
+    # The integer column with three distinct values should become categorical.
+    assert steps["numeric_to_categorical"]["applied"], report["steps"]
+    assert "str" in survivors
+
+    # Gaps in the first column must be counted, not silently dropped.
+    assert any(int(column.get("nan_number", 0)) > 0 for column in report["source_types"])
+
+
+def test_preprocessing_needs_a_target(client: TestClient, tmp_path: Path) -> None:
+    import pandas as pd
+
+    path = tmp_path / "untargeted.csv"
+    pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).to_csv(path, index=False)
+    with path.open("rb") as handle:
+        uid = client.post(
+            "/api/datasets", files={"file": ("untargeted.csv", handle, "text/csv")}
+        ).json()["uid"]
+
+    # The uploader guesses a target, so clear it to reach the error path.
+    from fedotweb.settings import get_settings
+    from fedotweb.storage.sqlite import Store
+
+    store = Store(get_settings().database_path)
+    record = store.get_dataset(uid)
+    record["target"] = None
+    store.save_dataset(record)
+
+    response = client.get(f"/api/datasets/{uid}/preprocessing")
+    assert response.status_code == 422
+    assert "target" in response.json()["detail"].lower()
+
+
+# -------------------------------------------------------------- objective detail
+
+
+def test_objective_breakdown_reports_each_fold_and_the_holdout(
+    client: TestClient, finished_run: str
+) -> None:
+    started = client.post(f"/api/runs/{finished_run}/analyses", json={"kind": "objective"})
+    assert started.status_code == 202, started.text
+
+    record = await_analysis(client, started.json()["uid"])
+    assert record["status"] == "finished", record["error"]
+    result = record["result"]
+
+    assert result["cv_folds"] == 3
+    assert len(result["folds"]) == 3
+    assert result["primary_metric"] == "roc_auc"
+
+    scored = [fold for fold in result["folds"] if not fold["failed"]]
+    assert scored, "no fold produced a score"
+
+    # The reported mean must actually be the mean of the folds -- that identity is
+    # the whole claim the window makes.
+    values = [fold["metrics"]["roc_auc"] for fold in scored if fold["metrics"].get("roc_auc")]
+    assert values
+    assert result["summary"]["roc_auc"]["mean"] == pytest.approx(sum(values) / len(values))
+    assert result["summary"]["roc_auc"]["folds_used"] == len(values)
+
+    # ROC AUC is maximised, so FEDOT stores it negated; the readable value flips back.
+    summary = result["summary"]["roc_auc"]
+    assert summary["is_maximised"] is True
+    assert summary["readable_mean"] == pytest.approx(-summary["mean"])
+
+    assert result["holdout"]["size"] > 0
+    assert "roc_auc" in result["holdout"]["metrics"]
+
+
+def test_analysis_is_listed_against_its_run(client: TestClient, finished_run: str) -> None:
+    started = client.post(f"/api/runs/{finished_run}/analyses", json={"kind": "objective"})
+    analysis_uid = started.json()["uid"]
+    await_analysis(client, analysis_uid)
+
+    listed = client.get(f"/api/runs/{finished_run}/analyses").json()
+    assert any(item["uid"] == analysis_uid for item in listed)
+
+
+def test_analysis_of_an_unknown_run_is_rejected(client: TestClient) -> None:
+    assert client.post("/api/runs/nope/analyses", json={"kind": "objective"}).status_code == 404
+    assert client.get("/api/analyses/nope").status_code == 404
+
+
+# ------------------------------------------------------------------- sensitivity
+
+
+def test_sensitivity_scores_every_node(client: TestClient, finished_run: str) -> None:
+    started = client.post(
+        f"/api/runs/{finished_run}/analyses",
+        json={"kind": "sensitivity", "replacements": 1, "analyse_edges": False},
+    )
+    assert started.status_code == 202, started.text
+
+    record = await_analysis(client, started.json()["uid"])
+    assert record["status"] == "finished", record["error"]
+    result = record["result"]
+
+    assert result["metric"] == "roc_auc"
+    nodes = [entity for entity in result["entities"] if entity["entity_type"] == "node"]
+    assert nodes, "no node was analysed"
+
+    for node in nodes:
+        # Every node must be identifiable and carry a comparable number.
+        assert node["operation"], node
+        assert node["worst"] is None or isinstance(node["worst"].get("value"), (int, float))
+
+        # The verdict is decided server-side: GOLEM's ratio is sign-normalised,
+        # so `> 1` always means the change improved the objective.
+        assert node["improves"] in (True, False, None)
+        assert node["severity"] >= 0
+        value = (node["worst"] or {}).get("value")
+        if isinstance(value, (int, float)) and value != -1.0:
+            assert node["improves"] is (value > 1)

--- a/backend/tests/test_attach.py
+++ b/backend/tests/test_attach.py
@@ -1,0 +1,107 @@
+"""Watching a run that was started from a user's own script."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("FEDOTWEB_WORKSPACE", str(tmp_path / "workspace"))
+    # A free-ish port, so the test never fights a server the developer is running.
+    monkeypatch.setenv("FEDOTWEB_PORT", "8931")
+
+    import fedotweb.settings as settings_module
+
+    settings_module._settings = None  # noqa: SLF001 - reset the cached singleton
+    return tmp_path
+
+
+@pytest.fixture()
+def dataset(tmp_path: Path) -> Path:
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(19)
+    size = 300
+    x1, x2 = rng.normal(size=size), rng.normal(size=size)
+    frame = pd.DataFrame({"x1": x1, "x2": x2, "target": ((x1 - x2) > 0).astype(int)})
+    path = tmp_path / "attached.csv"
+    frame.to_csv(path, index=False)
+    return path
+
+
+def test_a_scripted_run_reports_into_the_gui(workspace: Path, dataset: Path) -> None:
+    from fedot import Fedot
+
+    from fedotweb import watch
+    from fedotweb.settings import get_settings
+    from fedotweb.storage.sqlite import Store
+
+    with watch("scripted", open_browser=False, config={"problem": "classification"}) as session:
+        run_uid = session.uid
+        assert run_uid in session.url
+
+        model = Fedot(
+            problem="classification",
+            timeout=0.6,
+            preset="fast_train",
+            seed=3,
+            pop_size=4,
+            num_of_generations=3,
+            with_tuning=False,
+            cv_folds=2,
+            n_jobs=1,
+            optimizer=session.optimizer,
+        )
+        model.fit(features=str(dataset), target="target")
+        session.record_result(model)
+
+    store = Store(get_settings().database_path)
+    record = store.get_run(run_uid)
+    assert record is not None
+    assert record["status"] == "finished"
+    assert record["config"]["origin"] == "attached"
+    assert record["best_pipeline"], "the fitted pipeline was not stored"
+
+    events = store.list_events(run_uid)
+    kinds = {event["kind"] for event in events}
+    assert "generation" in kinds, "no progress was reported"
+    assert "population" in kinds, "no ancestry was reported"
+    assert "finished" in kinds
+
+    # The genealogy must be derivable from what the script reported, exactly as
+    # for a run the GUI started itself.
+    from fedotweb.history import live_lineage_graph
+
+    graph = live_lineage_graph(events)
+    assert graph is not None and graph["nodes"]
+
+    # Fitting without predicting leaves no honest metric, and a made-up one would
+    # be worse than none.
+    assert record["metrics"] is None
+
+
+def test_the_server_starts_once_and_is_reused(workspace: Path) -> None:
+    from fedotweb.attach import ensure_server
+
+    first = ensure_server()
+    second = ensure_server()
+    assert first == second
+
+    import urllib.request
+
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{first}/api/health") as response:
+                assert response.status == 200
+                return
+        except Exception:
+            time.sleep(0.5)
+    pytest.fail("the attached server never answered")

--- a/backend/tests/test_cancellation.py
+++ b/backend/tests/test_cancellation.py
@@ -1,0 +1,169 @@
+"""Stopping a run must leave it recorded as cancelled, not as a failure."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("FEDOTWEB_WORKSPACE", str(tmp_path / "workspace"))
+    monkeypatch.setenv("FEDOTWEB_MAX_CONCURRENT_RUNS", "1")
+
+    import fedotweb.settings as settings_module
+
+    settings_module._settings = None  # noqa: SLF001 - reset the cached singleton
+
+    from fedotweb.main import create_app
+
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def dataset_uid(client: TestClient, tmp_path: Path) -> str:
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(3)
+    size = 400
+    x1, x2 = rng.normal(size=size), rng.normal(size=size)
+    frame = pd.DataFrame({"x1": x1, "x2": x2, "target": ((x1 - x2) > 0).astype(int)})
+    path = tmp_path / "cancel.csv"
+    frame.to_csv(path, index=False)
+
+    with path.open("rb") as handle:
+        response = client.post(
+            "/api/datasets",
+            files={"file": ("cancel.csv", handle, "text/csv")},
+            data={"task": "classification"},
+        )
+    assert response.status_code == 201, response.text
+    return response.json()["uid"]
+
+
+def test_stopping_a_run_records_it_as_cancelled(client: TestClient, dataset_uid: str) -> None:
+    response = client.post(
+        "/api/runs",
+        json={
+            "name": "long",
+            "config": {
+                "problem": "classification",
+                "dataset_uid": dataset_uid,
+                "target": "target",
+                # Long enough that the run is certainly still going when stopped.
+                "timeout": 30,
+                "preset": "best_quality",
+                "pop_size": 20,
+                "num_of_generations": 50,
+                "with_tuning": False,
+                "cv_folds": 3,
+                "n_jobs": 1,
+                "seed": 1,
+            },
+        },
+    )
+    assert response.status_code == 202, response.text
+    run_uid = response.json()["uid"]
+
+    # Wait until composition is genuinely under way before stopping.
+    deadline = time.monotonic() + 120
+    while time.monotonic() < deadline:
+        events = client.get(f"/api/runs/{run_uid}/events").json()
+        if any(event["kind"] == "generation" for event in events):
+            break
+        assert not any(event["kind"] == "error" for event in events), events
+        time.sleep(1.5)
+    else:
+        pytest.fail("the run never reached its first generation")
+
+    # The genealogy must be available *while* the run is going -- that is what
+    # makes it usable for monitoring rather than only for post-mortems.
+    live = client.get(f"/api/runs/{run_uid}/lineage")
+    assert live.status_code == 200, live.text
+    graph = live.json()
+    assert graph["source"] == "live" and graph["is_live"] is True
+    assert graph["nodes"], "the live genealogy is empty"
+
+    known_ids = {node["id"] for node in graph["nodes"]}
+    for edge in graph["edges"]:
+        assert edge["source"] in known_ids and edge["target"] in known_ids
+
+    # Nothing is final until the run ends; the leader is marked as best so far.
+    individuals = [node for node in graph["nodes"] if node["kind"] == "individual"]
+    assert not any(node["is_final_choice"] for node in individuals)
+    assert any(node["is_current_best"] for node in individuals)
+
+    # And a node in the live graph must open the pipeline it stands for.
+    pipeline = client.get(f"/api/runs/{run_uid}/lineage/{individuals[0]['uid']}")
+    assert pipeline.status_code == 200, pipeline.text
+    assert pipeline.json()["nodes"]
+
+    assert client.post(f"/api/runs/{run_uid}/stop").status_code == 200
+
+    # The tail finalises asynchronously once the worker is gone.
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        record = client.get(f"/api/runs/{run_uid}").json()
+        if record["status"] not in {"running", "pending"}:
+            break
+        time.sleep(1.0)
+
+    assert record["status"] == "cancelled", record
+    assert record["error"] is None
+
+    # The concurrency slot must be free again immediately.
+    again = client.post(
+        "/api/runs",
+        json={
+            "config": {
+                "problem": "classification",
+                "dataset_uid": dataset_uid,
+                "target": "target",
+                "timeout": 0.5,
+                "preset": "fast_train",
+                "pop_size": 3,
+                "num_of_generations": 2,
+                "with_tuning": False,
+                "cv_folds": 2,
+                "n_jobs": 1,
+            }
+        },
+    )
+    assert again.status_code == 202, again.text
+    client.post(f"/api/runs/{again.json()['uid']}/stop")
+
+
+def test_stopping_a_finished_run_is_a_conflict(client: TestClient, dataset_uid: str) -> None:
+    response = client.post(
+        "/api/runs",
+        json={
+            "config": {
+                "problem": "classification",
+                "dataset_uid": dataset_uid,
+                "target": "target",
+                "timeout": 0.5,
+                "preset": "fast_train",
+                "pop_size": 3,
+                "num_of_generations": 2,
+                "with_tuning": False,
+                "cv_folds": 2,
+                "n_jobs": 1,
+            }
+        },
+    )
+    run_uid = response.json()["uid"]
+
+    deadline = time.monotonic() + 300
+    while time.monotonic() < deadline:
+        if client.get(f"/api/runs/{run_uid}").json()["status"] not in {"running", "pending"}:
+            break
+        time.sleep(2.0)
+
+    assert client.post(f"/api/runs/{run_uid}/stop").status_code == 409

--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -1,0 +1,107 @@
+"""The hyperparameter schemas are what the UI's typed editor is built on."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from fedotweb.catalog import get_catalog
+
+
+@pytest.fixture(scope="module")
+def catalog():
+    return get_catalog()
+
+
+def test_catalogue_covers_models_and_data_operations(catalog) -> None:
+    operations = catalog.list_operations()
+    kinds = {operation["kind"] for operation in operations}
+
+    assert len(operations) > 50
+    assert {"model", "data_operation"} <= kinds
+    assert {operation["id"] for operation in operations} >= {"rf", "logit", "scaling", "pca"}
+
+
+def test_task_filter_excludes_incompatible_operations(catalog) -> None:
+    classification = {op["id"] for op in catalog.list_operations(task="classification")}
+    forecasting = {op["id"] for op in catalog.list_operations(task="ts_forecasting")}
+
+    assert "logit" in classification
+    assert "logit" not in forecasting
+    assert "lagged" in forecasting
+
+
+def test_unknown_task_is_rejected(catalog) -> None:
+    with pytest.raises(ValueError):
+        catalog.list_operations(task="nonsense")
+
+
+def test_continuous_parameter_carries_its_sampling_scope(catalog) -> None:
+    parameters = {p["name"]: p for p in catalog.get("rf")["parameters"]}
+
+    max_features = parameters["max_features"]
+    assert max_features["type"] == "continuous"
+    assert max_features["tunable"] is True
+    assert max_features["minimum"] == pytest.approx(0.05)
+    assert max_features["maximum"] == pytest.approx(1.0)
+    assert max_features["value_type"] == "number"
+
+
+def test_discrete_and_categorical_parameters(catalog) -> None:
+    parameters = {p["name"]: p for p in catalog.get("rf")["parameters"]}
+
+    assert parameters["min_samples_split"]["type"] == "discrete"
+    assert parameters["min_samples_split"]["value_type"] == "integer"
+
+    criterion = parameters["criterion"]
+    assert criterion["type"] == "categorical"
+    assert criterion["choices"] == ["gini", "entropy"]
+
+
+def test_log_scale_is_detected(catalog) -> None:
+    """`hp.loguniform` scopes must be flagged so the slider can be logarithmic."""
+    learning_rate = next(
+        p for p in catalog.get("adareg")["parameters"] if p["name"] == "learning_rate"
+    )
+    assert learning_rate["distribution"] == "loguniform"
+    assert learning_rate["log_scale"] is True
+
+
+def test_defaults_are_merged_into_the_schema(catalog) -> None:
+    n_components = next(
+        p for p in catalog.get("pca")["parameters"] if p["name"] == "n_components"
+    )
+    assert n_components["default"] == pytest.approx(0.7)
+    assert n_components["minimum"] is not None and n_components["maximum"] is not None
+
+
+def test_parameters_with_only_a_default_are_still_editable(catalog) -> None:
+    """`n_jobs` is not tuned, but the user must still be able to change it."""
+    n_jobs = next(p for p in catalog.get("rf")["parameters"] if p["name"] == "n_jobs")
+    assert n_jobs["tunable"] is False
+    assert n_jobs["default"] == 1
+    assert n_jobs["value_type"] == "integer"
+
+
+def test_nested_search_space_is_decoded(catalog) -> None:
+    """`glm` nests its parameters; each variant must expose its own options."""
+    nested = next(p for p in catalog.get("glm")["parameters"] if p["type"] == "nested")
+
+    labels = {variant["label"] for variant in nested["nested_variants"]}
+    assert labels == {"gaussian", "gamma", "inverse_gaussian"}
+
+    gaussian = next(v for v in nested["nested_variants"] if v["label"] == "gaussian")
+    assert gaussian["fixed"] == {"family": "gaussian"}
+    assert gaussian["options"]["link"] == ["identity", "inverse_power", "log"]
+
+
+def test_every_schema_is_json_serialisable(catalog) -> None:
+    """Nothing may leak a hyperopt object, NaN or infinity into the API payload."""
+    for operation in catalog.list_operations(with_parameters=True):
+        json.dumps(operation, allow_nan=False)
+
+
+def test_unknown_operation_returns_none(catalog) -> None:
+    assert catalog.get("no_such_operation") is None
+    assert catalog.exists("no_such_operation") is False

--- a/backend/tests/test_control.py
+++ b/backend/tests/test_control.py
@@ -1,0 +1,178 @@
+"""Changing the evolution while it runs.
+
+GOLEM re-derives population size and operator probabilities at the start of every
+generation, so these tests pin down the part that is easy to get wrong: an
+override has to survive that update, and releasing it has to hand control back.
+"""
+
+from __future__ import annotations
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from fedotweb.runs.control import (
+    EvolutionControls,
+    apply_controls,
+    coerce_patch,
+    describe_effective,
+    install_overrides,
+    read_controls,
+    write_controls,
+)
+
+
+class FakeAdaptive:
+    """Stands in for GOLEM's adaptive parameter: a value that drifts each call."""
+
+    def __init__(self, start: int = 10) -> None:
+        self._value = start
+
+    @property
+    def initial(self):
+        return self._value
+
+    def next(self, _population):
+        self._value += 1
+        return self._value
+
+
+class FakeProbabilities:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    @property
+    def initial(self):
+        return (0.8, 0.8)
+
+    def next(self, _population):
+        self.calls += 1
+        return (0.8, 0.8)
+
+
+def make_optimizer(generation: int = 3):
+    optimizer = SimpleNamespace(
+        graph_optimizer_params=SimpleNamespace(pop_size=10, mutation_prob=0.8, crossover_prob=0.8),
+        requirements=SimpleNamespace(num_of_generations=40, timeout=None, max_depth=5),
+        timer=SimpleNamespace(timeout=datetime.timedelta(minutes=10)),
+        current_generation_num=generation,
+    )
+    optimizer._pop_size = FakeAdaptive()
+    optimizer._operators_prob = FakeProbabilities()
+    install_overrides(optimizer)
+    return optimizer
+
+
+# ---------------------------------------------------------------------- patches
+
+
+def test_unknown_fields_are_dropped_and_values_clamped() -> None:
+    cleaned = coerce_patch(
+        {"pop_size": 10_000, "mutation_prob": 5.0, "nonsense": 1, "finish_now": "yes"}
+    )
+    assert cleaned["pop_size"] == 500  # upper bound
+    assert cleaned["mutation_prob"] == 1.0
+    assert cleaned["finish_now"] is True
+    assert "nonsense" not in cleaned
+
+
+def test_controls_round_trip_through_the_run_directory(tmp_path) -> None:
+    assert read_controls(tmp_path) == EvolutionControls()
+
+    write_controls(tmp_path, {"pop_size": 24})
+    write_controls(tmp_path, {"mutation_prob": 0.3})
+
+    stored = read_controls(tmp_path)
+    assert stored.pop_size == 24
+    assert stored.mutation_prob == pytest.approx(0.3)
+
+
+def test_a_corrupt_control_file_is_ignored(tmp_path) -> None:
+    """A half-written file must not take the run down."""
+    (tmp_path / "control.json").write_text("{not json", encoding="utf-8")
+    assert read_controls(tmp_path) == EvolutionControls()
+
+
+# --------------------------------------------------------------------- applying
+
+
+def test_population_override_survives_the_adaptive_update() -> None:
+    """The whole point: GOLEM would otherwise overwrite this next generation."""
+    optimizer = make_optimizer()
+    apply_controls(optimizer, EvolutionControls(pop_size=24))
+
+    assert optimizer.graph_optimizer_params.pop_size == 24
+    # What GOLEM asks for on the following generations.
+    assert optimizer._pop_size.next(None) == 24
+    assert optimizer._pop_size.next(None) == 24
+
+
+def test_releasing_an_override_returns_control_to_golem() -> None:
+    optimizer = make_optimizer()
+    apply_controls(optimizer, EvolutionControls(pop_size=24))
+    changes = apply_controls(optimizer, EvolutionControls(pop_size=None))
+
+    assert any("adaptive" in change for change in changes)
+    # The wrapped policy kept advancing underneath, so it resumes where it was.
+    assert optimizer._pop_size.next(None) != 24
+
+
+def test_operator_probabilities_are_independently_overridable() -> None:
+    optimizer = make_optimizer()
+    apply_controls(optimizer, EvolutionControls(mutation_prob=0.35))
+
+    mutation, crossover = optimizer._operators_prob.next(None)
+    assert mutation == pytest.approx(0.35)
+    assert crossover == pytest.approx(0.8), "crossover must stay with GOLEM"
+
+    apply_controls(optimizer, EvolutionControls(mutation_prob=0.35, crossover_prob=0.15))
+    mutation, crossover = optimizer._operators_prob.next(None)
+    assert (mutation, crossover) == (pytest.approx(0.35), pytest.approx(0.15))
+
+
+def test_generation_limit_and_time_budget_are_assigned() -> None:
+    optimizer = make_optimizer()
+    changes = apply_controls(
+        optimizer, EvolutionControls(num_of_generations=99, timeout_minutes=20)
+    )
+
+    assert optimizer.requirements.num_of_generations == 99
+    assert optimizer.timer.timeout == datetime.timedelta(minutes=20)
+    assert len(changes) == 2
+
+
+def test_reapplying_the_same_controls_reports_no_change() -> None:
+    """The run log should not fill with repeats of a setting that already holds."""
+    optimizer = make_optimizer()
+    controls = EvolutionControls(pop_size=24, num_of_generations=99)
+
+    assert apply_controls(optimizer, controls)
+    assert apply_controls(optimizer, controls) == []
+
+
+def test_finish_now_trips_the_stopping_condition() -> None:
+    """GOLEM stops at `current >= num_of_generations + 1`, so the limit must go below."""
+    optimizer = make_optimizer(generation=7)
+    changes = apply_controls(optimizer, EvolutionControls(finish_now=True))
+
+    assert optimizer.requirements.num_of_generations == 6
+    assert optimizer.current_generation_num >= optimizer.requirements.num_of_generations + 1
+    assert any("keeping the best result" in change for change in changes)
+
+
+def test_installing_overrides_twice_does_not_nest_them() -> None:
+    optimizer = make_optimizer()
+    inner = optimizer._pop_size
+    install_overrides(optimizer)
+    assert optimizer._pop_size is inner
+
+
+def test_effective_description_reports_what_is_in_force() -> None:
+    optimizer = make_optimizer(generation=4)
+    apply_controls(optimizer, EvolutionControls(pop_size=24, timeout_minutes=20))
+
+    described = describe_effective(optimizer)
+    assert described["pop_size"] == 24
+    assert described["generation"] == 4
+    assert described["timeout_minutes"] == pytest.approx(20.0)

--- a/backend/tests/test_convert.py
+++ b/backend/tests/test_convert.py
@@ -1,0 +1,153 @@
+"""Round-tripping between FEDOT pipelines and the editor's graph format."""
+
+from __future__ import annotations
+
+import pytest
+from fedot.core.pipelines.node import PipelineNode
+from fedot.core.pipelines.pipeline import Pipeline
+
+from fedotweb.pipelines.convert import (
+    PipelineConversionError,
+    graph_to_pipeline,
+    pipeline_to_graph,
+    validate_graph,
+)
+
+
+def edges_of(graph) -> set:
+    return {(edge["source"], edge["target"]) for edge in graph["edges"]}
+
+
+def test_chain_round_trips() -> None:
+    scaling = PipelineNode("scaling")
+    root = PipelineNode("rf", nodes_from=[scaling])
+    graph = pipeline_to_graph(Pipeline([scaling, root]))
+
+    assert [node["operation"] for node in graph["nodes"]] == ["scaling", "rf"]
+    assert graph["depth"] == 2 and graph["length"] == 2
+
+    rebuilt = pipeline_to_graph(graph_to_pipeline(graph))
+    assert edges_of(rebuilt) == edges_of(graph)
+
+
+def test_diamond_topology_survives() -> None:
+    scaling = PipelineNode("scaling")
+    left = PipelineNode("rf", nodes_from=[scaling])
+    right = PipelineNode("logit", nodes_from=[scaling])
+    root = PipelineNode("xgboost", nodes_from=[left, right])
+
+    graph = pipeline_to_graph(Pipeline([scaling, left, right, root]))
+    assert len(graph["nodes"]) == 4
+    assert len(graph["edges"]) == 4
+
+    rebuilt = pipeline_to_graph(graph_to_pipeline(graph))
+    assert edges_of(rebuilt) == edges_of(graph)
+
+
+def test_identical_parallel_branches_are_not_merged() -> None:
+    """Two structurally identical branches are distinct nodes, not one.
+
+    De-duplicating by descriptive id — as the previous implementation did —
+    silently collapses this pipeline into a three-node chain.
+    """
+    graph = {
+        "nodes": [
+            {"id": "s", "operation": "scaling", "params": {}},
+            {"id": "a", "operation": "rf", "params": {}},
+            {"id": "b", "operation": "rf", "params": {}},
+            {"id": "r", "operation": "logit", "params": {}},
+        ],
+        "edges": [
+            {"source": "s", "target": "a"},
+            {"source": "s", "target": "b"},
+            {"source": "a", "target": "r"},
+            {"source": "b", "target": "r"},
+        ],
+    }
+    pipeline = graph_to_pipeline(graph)
+    assert pipeline.length == 4
+
+
+def test_parameters_round_trip() -> None:
+    graph = {
+        "nodes": [
+            {"id": "s", "operation": "scaling", "params": {}},
+            {"id": "r", "operation": "rf", "params": {"n_jobs": 1, "criterion": "entropy"}},
+        ],
+        "edges": [{"source": "s", "target": "r"}],
+    }
+    described = pipeline_to_graph(graph_to_pipeline(graph))
+    root = next(node for node in described["nodes"] if node["operation"] == "rf")
+    assert root["params"]["criterion"] == "entropy"
+
+
+def test_integer_node_ids_are_accepted() -> None:
+    """The legacy frontend numbered its nodes; those payloads must still load."""
+    graph = {
+        "nodes": [
+            {"id": 0, "operation": "scaling", "params": {}},
+            {"id": 1, "operation": "rf", "params": {}},
+        ],
+        "edges": [{"source": 0, "target": 1}],
+    }
+    assert graph_to_pipeline(graph).length == 2
+
+
+def test_cycles_are_rejected() -> None:
+    graph = {
+        "nodes": [
+            {"id": "a", "operation": "scaling", "params": {}},
+            {"id": "b", "operation": "rf", "params": {}},
+        ],
+        "edges": [{"source": "a", "target": "b"}, {"source": "b", "target": "a"}],
+    }
+    with pytest.raises(PipelineConversionError, match="cycle"):
+        graph_to_pipeline(graph)
+
+    is_valid, problems = validate_graph(graph, task="classification")
+    assert not is_valid
+    assert any("cycle" in problem for problem in problems)
+
+
+def test_empty_graph_is_rejected() -> None:
+    with pytest.raises(PipelineConversionError, match="empty"):
+        graph_to_pipeline({"nodes": [], "edges": []})
+
+
+def test_edge_to_unknown_node_is_rejected() -> None:
+    graph = {
+        "nodes": [{"id": "a", "operation": "rf", "params": {}}],
+        "edges": [{"source": "a", "target": "ghost"}],
+    }
+    with pytest.raises(PipelineConversionError, match="unknown target"):
+        graph_to_pipeline(graph)
+
+
+def test_unknown_operation_is_reported() -> None:
+    graph = {"nodes": [{"id": "a", "operation": "not_a_model", "params": {}}], "edges": []}
+    is_valid, problems = validate_graph(graph)
+    assert not is_valid
+    assert any("Unknown operation" in problem for problem in problems)
+
+
+def test_validation_is_task_aware() -> None:
+    """A table model alone is fine for classification but not for forecasting."""
+    graph = {"nodes": [{"id": "a", "operation": "rf", "params": {}}], "edges": []}
+
+    assert validate_graph(graph, task="classification")[0] is True
+
+    is_valid, problems = validate_graph(graph, task="ts_forecasting")
+    assert is_valid is False
+    # The message must be readable rather than FEDOT's raw rule repr.
+    assert problems and "0x" not in problems[0]
+    assert "rule:" in problems[0]
+
+
+def test_multi_root_pipeline_can_still_be_described() -> None:
+    """The editor must be able to draw an invalid graph so it can be fixed."""
+    first = PipelineNode("rf")
+    second = PipelineNode("logit")
+    graph = pipeline_to_graph(Pipeline([first, second]))
+
+    assert len(graph["nodes"]) == 2
+    assert all(node["is_root"] is False for node in graph["nodes"])

--- a/backend/tests/test_lineage.py
+++ b/backend/tests/test_lineage.py
@@ -1,0 +1,234 @@
+"""Building the evolution genealogy from a GOLEM history."""
+
+from __future__ import annotations
+
+import pytest
+from golem.core.optimisers.fitness.fitness import SingleObjFitness
+from golem.core.optimisers.graph import OptGraph, OptNode
+from golem.core.optimisers.opt_history_objects.individual import Individual
+from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
+from golem.core.optimisers.opt_history_objects.parent_operator import ParentOperator
+
+from fedotweb.history.lineage import history_to_lineage
+
+
+def make_individual(operation: str, fitness: float, *, generation: int) -> Individual:
+    individual = Individual(graph=OptGraph(OptNode(operation)), fitness=SingleObjFitness(fitness))
+    individual.set_native_generation(generation)
+    return individual
+
+
+def descend(
+    child_operation: str,
+    fitness: float,
+    *,
+    parents: list[Individual],
+    operator: str,
+    generation: int,
+) -> Individual:
+    individual = Individual(
+        graph=OptGraph(OptNode(child_operation)),
+        fitness=SingleObjFitness(fitness),
+        parent_operator=ParentOperator(
+            type_=operator, operators=[f"{operator}_op"], parent_individuals=parents
+        ),
+    )
+    individual.set_native_generation(generation)
+    return individual
+
+
+@pytest.fixture()
+def history() -> OptHistory:
+    """A three-generation run: two founders, a crossover, then a mutation.
+
+        gen 0:  rf(-0.5)      logit(-0.6)
+                     \\        /
+        gen 1:        crossover -> child(-0.7),  logit survives
+                          |
+        gen 2:        mutation  -> winner(-0.9)
+    """
+    built = OptHistory()
+
+    founder_a = make_individual("rf", -0.5, generation=0)
+    founder_b = make_individual("logit", -0.6, generation=0)
+    built.add_to_history([founder_a, founder_b])
+
+    child = descend("dt", -0.7, parents=[founder_a, founder_b], operator="crossover", generation=1)
+    # `founder_b` survives selection into generation 1 unchanged.
+    built.add_to_history([child, founder_b])
+
+    winner = descend("knn", -0.9, parents=[child], operator="mutation", generation=2)
+    built.add_to_history([winner, child])
+
+    built.add_to_history([winner], "final_choices")
+    return built
+
+
+def nodes_of(graph: dict, kind: str) -> list[dict]:
+    return [node for node in graph["nodes"] if node["kind"] == kind]
+
+
+def test_winning_path_keeps_only_the_ancestry(history: OptHistory) -> None:
+    graph = history_to_lineage(history, only_winning_path=True)
+
+    individuals = nodes_of(graph, "individual")
+    uids = {node["uid"] for node in individuals}
+
+    # Both founders are ancestors of the winner, so all four individuals appear.
+    assert len(uids) == 4
+    assert all(node["on_winning_path"] for node in individuals)
+
+
+def test_operators_sit_between_the_generations_they_join(history: OptHistory) -> None:
+    graph = history_to_lineage(history, only_winning_path=True)
+    operators = nodes_of(graph, "operator")
+
+    types = {node["operator_type"] for node in operators}
+    assert types == {"crossover", "mutation"}
+
+    for operator in operators:
+        # Odd layers are reserved for operators; individuals occupy even ones.
+        assert operator["layer"] % 2 == 1
+        assert operator["layer"] == operator["generation"] * 2 - 1
+
+
+def test_crossover_is_linked_to_both_parents(history: OptHistory) -> None:
+    graph = history_to_lineage(history, only_winning_path=True)
+    crossover = next(n for n in nodes_of(graph, "operator") if n["operator_type"] == "crossover")
+
+    incoming = [edge for edge in graph["edges"] if edge["target"] == crossover["id"]]
+    assert len(incoming) == 2, "a crossover must show where both parents came from"
+
+    outgoing = [edge for edge in graph["edges"] if edge["source"] == crossover["id"]]
+    assert len(outgoing) == 1
+    assert outgoing[0]["kind"] == "produces"
+
+
+def test_a_surviving_individual_is_linked_across_generations(history: OptHistory) -> None:
+    graph = history_to_lineage(history, only_winning_path=True)
+    survival = [edge for edge in graph["edges"] if edge["kind"] == "survival"]
+
+    assert survival, "an individual carried into the next generation must stay connected"
+    for edge in survival:
+        source = next(n for n in graph["nodes"] if n["id"] == edge["source"])
+        target = next(n for n in graph["nodes"] if n["id"] == edge["target"])
+        assert source["uid"] == target["uid"]
+        assert target["generation"] == source["generation"] + 1
+
+
+def test_final_choice_and_generation_best_are_marked(history: OptHistory) -> None:
+    graph = history_to_lineage(history, only_winning_path=True)
+    individuals = nodes_of(graph, "individual")
+
+    finals = [node for node in individuals if node["is_final_choice"]]
+    assert finals and all(node["fitness"] == pytest.approx(-0.9) for node in finals)
+
+    # The lowest fitness in generation 0 is the founder scoring -0.6.
+    generation_zero = [node for node in individuals if node["generation"] == 0]
+    best = [node for node in generation_zero if node["is_best_in_generation"]]
+    assert len(best) == 1
+    assert best[0]["fitness"] == pytest.approx(-0.6)
+
+
+def test_full_mode_is_a_superset(history: OptHistory) -> None:
+    winning = history_to_lineage(history, only_winning_path=True)
+    full = history_to_lineage(history, only_winning_path=False)
+
+    assert len(full["nodes"]) >= len(winning["nodes"])
+    assert {node["id"] for node in winning["nodes"]} <= {node["id"] for node in full["nodes"]}
+
+
+def test_edges_never_reference_a_missing_node(history: OptHistory) -> None:
+    for only_winning in (True, False):
+        graph = history_to_lineage(history, only_winning_path=only_winning)
+        known = {node["id"] for node in graph["nodes"]}
+        for edge in graph["edges"]:
+            assert edge["source"] in known, edge
+            assert edge["target"] in known, edge
+
+
+def test_individual_cap_is_reported(history: OptHistory) -> None:
+    graph = history_to_lineage(history, only_winning_path=False, max_individuals=2)
+    assert graph["truncated"] is True
+    assert len(nodes_of(graph, "individual")) <= 2
+
+
+def test_an_empty_history_yields_an_empty_graph() -> None:
+    graph = history_to_lineage(OptHistory(), only_winning_path=True)
+    assert graph["nodes"] == []
+    assert graph["edges"] == []
+    assert graph["generations"] == 0
+
+
+def test_an_individual_that_skips_a_generation_stays_connected() -> None:
+    """Elitism can reintroduce a pipeline after it left the population.
+
+    Linking only to the immediately preceding generation leaves the returning
+    node with no incoming edge, which reads as a pipeline out of nowhere.
+    """
+    built = OptHistory()
+
+    founder = make_individual("rf", -0.5, generation=0)
+    other = make_individual("logit", -0.4, generation=0)
+    built.add_to_history([founder, other])
+
+    # `founder` is absent from generation 1 entirely.
+    built.add_to_history([other])
+    # ...and comes back in generation 2.
+    built.add_to_history([founder, other])
+
+    child = descend("dt", -0.9, parents=[founder], operator="mutation", generation=3)
+    built.add_to_history([child])
+    built.add_to_history([child], "final_choices")
+
+    graph = history_to_lineage(built, only_winning_path=False)
+
+    incoming = {edge["target"] for edge in graph["edges"]}
+    first_layer = min(node["layer"] for node in graph["nodes"])
+    orphans = [
+        node for node in graph["nodes"] if node["layer"] > first_layer and node["id"] not in incoming
+    ]
+    assert orphans == [], f"nodes with no way in: {[node['id'] for node in orphans]}"
+
+    # The survival edge must bridge the gap rather than be dropped.
+    returning = next(
+        node
+        for node in graph["nodes"]
+        if node["kind"] == "individual"
+        and node["generation"] == 2
+        and node["uid"] == str(founder.uid)
+    )
+    bridging = [
+        edge for edge in graph["edges"] if edge["target"] == returning["id"] and edge["kind"] == "survival"
+    ]
+    assert len(bridging) == 1
+    source = next(node for node in graph["nodes"] if node["id"] == bridging[0]["source"])
+    assert source["generation"] == 0
+
+
+def test_seed_and_result_rows_are_not_counted_as_evolution() -> None:
+    """GOLEM stores the assumptions and the result as generations of their own.
+
+    A run reporting ten stored generations may have evolved only seven times, and
+    the graph must not claim otherwise.
+    """
+    built = OptHistory()
+    founder = make_individual("rf", -0.5, generation=0)
+    built.add_to_history([founder], "initial_assumptions")
+
+    evolved = descend("dt", -0.8, parents=[founder], operator="mutation", generation=1)
+    built.add_to_history([evolved])
+    built.add_to_history([evolved], "final_choices")
+
+    graph = history_to_lineage(built, only_winning_path=False)
+
+    assert graph["generations"] == 3
+    assert graph["evolution_generations"] == 1
+
+    labels = {entry["index"]: entry["label"] for entry in graph["generation_meta"]}
+    assert labels[0] == "initial assumptions"
+    assert labels[1] == "gen 1"
+    assert labels[2] == "final choice"
+
+    flags = {entry["index"]: entry["is_evolutionary"] for entry in graph["generation_meta"]}
+    assert flags == {0: False, 1: True, 2: False}

--- a/backend/tests/test_live_lineage.py
+++ b/backend/tests/test_live_lineage.py
@@ -1,0 +1,301 @@
+"""Building the genealogy from progress events, while a run is still going."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fedotweb.history.live import individual_pipeline_from_events, lineage_from_events
+
+
+def population_event(
+    generation: int,
+    individuals: list[dict[str, Any]],
+    best_uids: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "kind": "population",
+        "payload": {
+            "generation": generation,
+            "individuals": individuals,
+            "best_uids": best_uids or [],
+        },
+    }
+
+
+def individual(
+    uid: str,
+    fitness: float,
+    operations: list[str],
+    *,
+    native: int,
+    operators: list[dict[str, Any]] | None = None,
+    graph: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "uid": uid,
+        "fitness": fitness,
+        "operations": operations,
+        "native_generation": native,
+    }
+    if operators is not None:
+        entry["operators"] = operators
+    if graph is not None:
+        entry["graph"] = graph
+    return entry
+
+
+@pytest.fixture()
+def events() -> list[dict[str, Any]]:
+    """Two generations: a founder pair, then a mutation of one of them."""
+    return [
+        {"kind": "status", "payload": {"status": "composing"}},
+        population_event(
+            1,
+            [
+                individual("a", -0.5, ["rf"], native=1),
+                individual("b", -0.6, ["logit"], native=1),
+            ],
+            best_uids=["b"],
+        ),
+        population_event(
+            2,
+            [
+                individual(
+                    "c",
+                    -0.8,
+                    ["dt"],
+                    native=2,
+                    operators=[
+                        {"uid": "op1", "type": "mutation", "label": "single_edge", "parents": ["b"]}
+                    ],
+                ),
+                # `b` survives selection unchanged.
+                individual("b", -0.6, ["logit"], native=1),
+            ],
+            best_uids=["c"],
+        ),
+    ]
+
+
+def nodes_of(graph: dict, kind: str) -> list[dict]:
+    return [node for node in graph["nodes"] if node["kind"] == kind]
+
+
+def test_no_population_events_yields_nothing() -> None:
+    assert lineage_from_events([{"kind": "status", "payload": {}}]) is None
+
+
+def test_generations_are_reindexed_from_zero(events) -> None:
+    """GOLEM counts generations from one; the graph's layers count from zero."""
+    graph = lineage_from_events(events, only_winning_path=False)
+
+    generations = sorted({node["generation"] for node in nodes_of(graph, "individual")})
+    assert generations == [0, 1]
+    assert graph["generations"] == 2
+    assert graph["evolution_generations"] == 2
+
+
+def test_operator_links_parent_to_child(events) -> None:
+    graph = lineage_from_events(events, only_winning_path=False)
+
+    operators = nodes_of(graph, "operator")
+    assert len(operators) == 1
+    assert operators[0]["operator_type"] == "mutation"
+    assert operators[0]["label"] == "single_edge"
+
+    incoming = [edge for edge in graph["edges"] if edge["target"] == operators[0]["id"]]
+    outgoing = [edge for edge in graph["edges"] if edge["source"] == operators[0]["id"]]
+    assert len(incoming) == 1 and incoming[0]["kind"] == "mutation"
+    assert len(outgoing) == 1 and outgoing[0]["kind"] == "produces"
+
+
+def test_survivors_are_linked_across_generations(events) -> None:
+    graph = lineage_from_events(events, only_winning_path=False)
+    survival = [edge for edge in graph["edges"] if edge["kind"] == "survival"]
+    assert len(survival) == 1
+
+
+def test_the_leader_is_marked_as_current_best_not_final(events) -> None:
+    """Nothing is final while the run is going."""
+    graph = lineage_from_events(events, only_winning_path=False)
+
+    leaders = [node for node in nodes_of(graph, "individual") if node.get("is_current_best")]
+    assert leaders and all(node["uid"] == "c" for node in leaders)
+    assert not any(node["is_final_choice"] for node in nodes_of(graph, "individual"))
+
+
+def test_winning_path_keeps_the_leader_ancestry(events) -> None:
+    graph = lineage_from_events(events, only_winning_path=True)
+    uids = {node["uid"] for node in nodes_of(graph, "individual")}
+    # `c` descends from `b`; `a` is unrelated and must be dropped.
+    assert uids == {"b", "c"}
+
+
+def test_a_repeated_generation_keeps_the_latest_payload() -> None:
+    """A replayed or resent generation must not double its population."""
+    duplicated = [
+        population_event(1, [individual("a", -0.5, ["rf"], native=1)]),
+        population_event(1, [individual("a", -0.55, ["rf"], native=1)], best_uids=["a"]),
+    ]
+    graph = lineage_from_events(duplicated, only_winning_path=False)
+
+    individuals = nodes_of(graph, "individual")
+    assert len(individuals) == 1
+    assert individuals[0]["fitness"] == pytest.approx(-0.55)
+
+
+def test_leader_falls_back_to_the_best_scored_individual() -> None:
+    """Before the archive reports anything, the lineage still needs a tip."""
+    without_best = [
+        population_event(
+            1,
+            [
+                individual("a", -0.2, ["rf"], native=1),
+                individual("b", -0.9, ["logit"], native=1),
+            ],
+        )
+    ]
+    graph = lineage_from_events(without_best, only_winning_path=True)
+    assert {node["uid"] for node in nodes_of(graph, "individual")} == {"b"}
+
+
+def test_edges_never_reference_a_missing_node(events) -> None:
+    for only_winning in (True, False):
+        graph = lineage_from_events(events, only_winning_path=only_winning)
+        known = {node["id"] for node in graph["nodes"]}
+        for edge in graph["edges"]:
+            assert edge["source"] in known and edge["target"] in known
+
+
+def test_individual_pipeline_is_reconstructed_from_the_stream() -> None:
+    """Clicking a node during a run must open the pipeline it stands for."""
+    streamed = [
+        population_event(
+            1,
+            [
+                individual(
+                    "a",
+                    -0.7,
+                    ["scaling", "rf"],
+                    native=1,
+                    graph={
+                        "nodes": [
+                            {"id": "n0", "operation": "scaling", "params": {}},
+                            {"id": "n1", "operation": "rf", "params": {"n_jobs": 2}},
+                        ],
+                        "edges": [{"source": "n0", "target": "n1"}],
+                    },
+                )
+            ],
+        )
+    ]
+
+    pipeline = individual_pipeline_from_events(streamed, "a")
+    assert pipeline is not None
+    assert [node["operation"] for node in pipeline["nodes"]] == ["scaling", "rf"]
+    assert pipeline["depth"] == 2
+    assert pipeline["fitness"] == pytest.approx(-0.7)
+
+    root = next(node for node in pipeline["nodes"] if node["operation"] == "rf")
+    assert root["params"] == {"n_jobs": 2}
+    assert root["is_root"] is True
+    # Catalogue metadata must be filled in so the editor canvas can draw it.
+    assert root["group"] and root["defaults"]
+
+    source = next(node for node in pipeline["nodes"] if node["operation"] == "scaling")
+    assert source["is_primary"] is True
+
+
+def test_unknown_individual_has_no_pipeline() -> None:
+    assert individual_pipeline_from_events([], "nope") is None
+
+
+def test_operators_survive_golems_offset_generation_counters() -> None:
+    """The two counters GOLEM exposes are offset by one, and the graph must cope.
+
+    A live population event carries the optimiser's ``current_generation_num``,
+    which starts at one, while each individual carries ``native_generation``,
+    which starts at zero. Deciding which generation "owns" an individual by
+    comparing those two silently drops every operator, leaving a genealogy of
+    nothing but survival edges.
+    """
+    offset_events = [
+        population_event(
+            1,  # optimiser counts from one...
+            [individual("a", -0.5, ["rf"], native=0)],  # ...individuals from zero
+        ),
+        population_event(
+            2,
+            [
+                individual(
+                    "b",
+                    -0.9,
+                    ["dt"],
+                    native=1,
+                    operators=[
+                        {"uid": "op1", "type": "mutation", "label": "single_edge", "parents": ["a"]}
+                    ],
+                ),
+                individual("a", -0.5, ["rf"], native=0),
+            ],
+            best_uids=["b"],
+        ),
+    ]
+
+    graph = lineage_from_events(offset_events, only_winning_path=True)
+
+    operators = nodes_of(graph, "operator")
+    assert operators, "the mutation that produced the leader was dropped"
+    assert operators[0]["operator_type"] == "mutation"
+
+    kinds = {edge["kind"] for edge in graph["edges"]}
+    assert "mutation" in kinds and "produces" in kinds
+
+
+def test_a_survivor_does_not_redraw_its_operators() -> None:
+    """An individual carried forward is linked as a survivor, not re-created."""
+    carried = [
+        population_event(1, [individual("a", -0.5, ["rf"], native=0)]),
+        population_event(
+            2,
+            [
+                individual(
+                    "b",
+                    -0.9,
+                    ["dt"],
+                    native=1,
+                    operators=[
+                        {"uid": "op1", "type": "mutation", "label": "m", "parents": ["a"]}
+                    ],
+                ),
+            ],
+            best_uids=["b"],
+        ),
+        # `b` survives; the worker resends its operators, which must be ignored here.
+        population_event(
+            3,
+            [
+                individual(
+                    "b",
+                    -0.9,
+                    ["dt"],
+                    native=1,
+                    operators=[
+                        {"uid": "op1", "type": "mutation", "label": "m", "parents": ["a"]}
+                    ],
+                ),
+            ],
+            best_uids=["b"],
+        ),
+    ]
+
+    graph = lineage_from_events(carried, only_winning_path=False)
+
+    operators = nodes_of(graph, "operator")
+    assert len(operators) == 1, "the operator must be drawn once, in the generation that used it"
+    assert operators[0]["generation"] == 1
+
+    survival = [edge for edge in graph["edges"] if edge["kind"] == "survival"]
+    assert len(survival) == 1

--- a/backend/tests/test_maintenance.py
+++ b/backend/tests/test_maintenance.py
@@ -1,0 +1,124 @@
+"""Housekeeping behaviours: restarts, deletions, and runs left without a worker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _fresh_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("FEDOTWEB_WORKSPACE", str(tmp_path / "workspace"))
+
+    import fedotweb.settings as settings_module
+
+    settings_module._settings = None  # noqa: SLF001 - reset the cached singleton
+
+    from fedotweb.main import create_app
+
+    return create_app
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    create_app = _fresh_app(tmp_path, monkeypatch)
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def _store():
+    from fedotweb.settings import get_settings
+    from fedotweb.storage.sqlite import Store
+
+    return Store(get_settings().database_path)
+
+
+def test_interrupted_analyses_fail_instead_of_running_forever(client: TestClient) -> None:
+    """An analysis orphaned by a restart would otherwise be polled indefinitely."""
+    store = _store()
+    run_uid = store.create_run(name="r", dataset_uid=None, config={})
+    analysis_uid = store.create_analysis(
+        run_uid=run_uid, kind="objective", pipeline_uid=None, options={}
+    )
+    assert store.get_analysis(analysis_uid)["status"] == "running"
+
+    marked = store.fail_running_analyses("The server restarted")
+    assert marked == 1
+
+    record = store.get_analysis(analysis_uid)
+    assert record["status"] == "failed"
+    assert "restarted" in record["error"]
+    assert record["finished_at"] is not None
+
+    # Finished analyses are left alone.
+    assert store.fail_running_analyses("again") == 0
+
+
+def test_deleting_a_run_removes_its_analyses(client: TestClient) -> None:
+    store = _store()
+    run_uid = store.create_run(name="r", dataset_uid=None, config={})
+    analysis_uid = store.create_analysis(
+        run_uid=run_uid, kind="objective", pipeline_uid=None, options={}
+    )
+
+    store.delete_run(run_uid)
+    assert store.get_analysis(analysis_uid) is None
+    assert store.list_analyses(run_uid) == []
+
+
+def test_a_run_without_a_worker_can_still_be_stopped(client: TestClient) -> None:
+    """A dead attached script, or a worker lost to a crash, must not leave a run
+    that shows as running forever with no way to end it from the GUI."""
+    store = _store()
+    run_uid = store.create_run(name="zombie", dataset_uid=None, config={"origin": "attached"})
+    store.update_run(run_uid, status="running")
+
+    response = client.post(f"/api/runs/{run_uid}/stop")
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "cancelled"
+
+    # A graceful-finish request is left behind for a script that is still alive.
+    from fedotweb.runs.control import read_controls
+    from fedotweb.settings import get_settings
+
+    assert read_controls(get_settings().runs_dir / run_uid).finish_now is True
+
+    # Stopping a run that already ended stays a conflict.
+    assert client.post(f"/api/runs/{run_uid}/stop").status_code == 409
+
+
+def test_restart_fails_owned_runs_but_not_attached_ones(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An attached run reports from the user's own process, which a GUI restart
+    does not interrupt — declaring it failed would falsify a live run."""
+    create_app = _fresh_app(tmp_path, monkeypatch)
+
+    with TestClient(create_app()):
+        store = _store()
+        attached = store.create_run(name="attached", dataset_uid=None, config={"origin": "attached"})
+        store.update_run(attached, status="running")
+        managed = store.create_run(name="managed", dataset_uid=None, config={})
+        store.update_run(managed, status="running")
+
+    # A second startup over the same workspace is the restart.
+    with TestClient(create_app()):
+        store = _store()
+        assert store.get_run(attached)["status"] == "running"
+        assert store.get_run(managed)["status"] == "failed"
+
+
+def test_event_kind_filter_matches_python_side_filtering(client: TestClient) -> None:
+    store = _store()
+    run_uid = store.create_run(name="r", dataset_uid=None, config={})
+    for kind in ("generation", "population", "log", "generation", "effective_params"):
+        store.append_event(run_uid, kind, {"kind": kind})
+
+    generations = store.list_events(run_uid, kinds=["generation"])
+    assert [event["kind"] for event in generations] == ["generation", "generation"]
+
+    both = store.list_events(run_uid, kinds=["generation", "log"])
+    assert [event["kind"] for event in both] == ["generation", "log", "generation"]
+
+    assert len(store.list_events(run_uid)) == 5

--- a/backend/tests/test_run_flow.py
+++ b/backend/tests/test_run_flow.py
@@ -1,0 +1,124 @@
+"""End-to-end check that the API can actually drive a FEDOT composition.
+
+This is the integration test the legacy project lacked: it uploads a dataset,
+starts a real (very short) AutoML run, follows the progress events and asserts
+that a best pipeline comes back in the editor's graph format.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("FEDOTWEB_WORKSPACE", str(tmp_path / "workspace"))
+    monkeypatch.setenv("FEDOTWEB_MAX_CONCURRENT_RUNS", "1")
+
+    import fedotweb.settings as settings_module
+
+    settings_module._settings = None  # noqa: SLF001 - reset the cached singleton
+
+    from fedotweb.main import create_app
+
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def dataset_csv(tmp_path: Path) -> Path:
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(7)
+    size = 400
+    x1 = rng.normal(size=size)
+    x2 = rng.normal(size=size)
+    score = 1.4 * x1 - 0.9 * x2 + rng.normal(scale=0.5, size=size)
+    frame = pd.DataFrame({"x1": x1, "x2": x2, "target": (score > 0).astype(int)})
+
+    path = tmp_path / "scoring.csv"
+    frame.to_csv(path, index=False)
+    return path
+
+
+def test_run_lifecycle(client: TestClient, dataset_csv: Path) -> None:
+    with dataset_csv.open("rb") as handle:
+        response = client.post(
+            "/api/datasets",
+            files={"file": ("scoring.csv", handle, "text/csv")},
+            data={"name": "scoring", "task": "classification"},
+        )
+    assert response.status_code == 201, response.text
+    dataset = response.json()
+    assert dataset["suggested_target"] == "target"
+    assert dataset["n_rows"] == 400
+    assert {column["name"] for column in dataset["columns"]} == {"x1", "x2", "target"}
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "name": "smoke",
+            "config": {
+                "problem": "classification",
+                "dataset_uid": dataset["uid"],
+                "target": "target",
+                "timeout": 0.6,
+                "preset": "fast_train",
+                "pop_size": 4,
+                "num_of_generations": 3,
+                "with_tuning": False,
+                "cv_folds": 2,
+                "n_jobs": 1,
+                "seed": 42,
+            },
+        },
+    )
+    assert response.status_code == 202, response.text
+    run_uid = response.json()["uid"]
+
+    deadline = time.monotonic() + 420
+    status = "running"
+    while time.monotonic() < deadline:
+        status = client.get(f"/api/runs/{run_uid}").json()["status"]
+        if status in {"finished", "failed", "cancelled"}:
+            break
+        time.sleep(2.0)
+
+    progress = client.get(f"/api/runs/{run_uid}/progress").json()
+    assert status == "finished", f"run ended as {status}: {progress['run'].get('error')}"
+
+    assert progress["generations"], "no generation events were recorded"
+    assert progress["best_pipeline"] is not None
+    assert progress["best_pipeline"]["nodes"], "the best pipeline has no nodes"
+    assert progress["run"]["metrics"], "no metrics were reported"
+
+    # The best pipeline must be stored and re-loadable as a pipeline record.
+    best_uid = progress["run"]["best_pipeline"]
+    assert best_uid
+    stored = client.get(f"/api/pipelines/{best_uid}")
+    assert stored.status_code == 200
+    assert stored.json()["graph"]["nodes"]
+
+    # The genealogy must be derivable from the history the worker saved, and every
+    # individual in it must resolve to a real pipeline.
+    lineage = client.get(f"/api/runs/{run_uid}/lineage")
+    assert lineage.status_code == 200, lineage.text
+    graph = lineage.json()
+    individuals = [node for node in graph["nodes"] if node["kind"] == "individual"]
+    assert individuals, "the genealogy has no individuals"
+
+    known_ids = {node["id"] for node in graph["nodes"]}
+    for edge in graph["edges"]:
+        assert edge["source"] in known_ids and edge["target"] in known_ids
+
+    sample = individuals[-1]
+    pipeline = client.get(f"/api/runs/{run_uid}/lineage/{sample['uid']}")
+    assert pipeline.status_code == 200, pipeline.text
+    assert pipeline.json()["nodes"]

--- a/docker-compose.v2.yaml
+++ b/docker-compose.v2.yaml
@@ -1,0 +1,17 @@
+services:
+  fedot-web:
+    build:
+      context: .
+      dockerfile: Dockerfile.v2
+    ports:
+      - "8000:8000"
+    volumes:
+      # Datasets, saved pipelines and run artefacts survive a rebuild.
+      - fedot-web-data:/data
+    environment:
+      FEDOTWEB_MAX_CONCURRENT_RUNS: "2"
+      FEDOTWEB_MAX_RUN_TIMEOUT_MINUTES: "240"
+    restart: unless-stopped
+
+volumes:
+  fedot-web-data:

--- a/docs/live_monitoring.md
+++ b/docs/live_monitoring.md
@@ -1,0 +1,86 @@
+# Live monitoring of a FEDOT run
+
+The GUI does not have to be the thing that launches FEDOT. You keep your own
+script, and the interface attaches to it: the server comes up by itself, a
+browser tab opens on the run's page, and every generation appears there as the
+optimiser works — the fitness curve, the live genealogy and the evolution
+controls.
+
+## One-time setup
+
+Install the `fedotweb` package into the same environment your FEDOT scripts
+use:
+
+```bash
+pip install -e backend
+```
+
+For the auto-started server to serve the web pages and share its data with a
+server you start by hand, set two environment variables (once, e.g. at the
+user level):
+
+```
+FEDOTWEB_STATIC_DIR=<repo>/ui/dist
+FEDOTWEB_WORKSPACE=<your workspace directory>
+```
+
+Without them the API starts without the web pages, and the workspace defaults
+to `~/.fedot-web`.
+
+## Option 1 — a single line
+
+Add the import **before** constructing `Fedot`:
+
+```python
+import fedotweb.autowatch  # noqa: F401  -- opens the GUI on every fit()
+
+from fedot import Fedot
+
+Fedot(problem='classification', timeout=10).fit(features='data.csv', target='target')
+```
+
+The import wraps `Fedot.fit`: when `fit()` is called, the server comes up in a
+background thread (an instance already listening on 127.0.0.1:8000 is reused,
+so several scripts can report into one GUI), the run is registered, a browser
+tab opens, and the evolution is streamed there live. An explicit `optimizer=`
+argument of your own is left alone.
+
+## Option 2 — name the run and record the result
+
+```python
+from fedot import Fedot
+from fedotweb import watch
+
+with watch('my experiment') as session:
+    model = Fedot(problem='classification', timeout=10, optimizer=session.optimizer)
+    model.fit(features=X, target=y)
+    model.predict(X_test)
+    session.record_result(model)  # stores the pipeline and its metrics in the GUI
+```
+
+`record_result` reports metrics only after a real `predict` — a "metric" taken
+after a bare `fit` would look like a score and mean nothing.
+
+## What you get while the run is going
+
+- **The fitness curve** — best-only by default with markers where the leading
+  pipeline changed; the tail after the last improvement is hidden, and a
+  caption says how many generations were cut.
+- **The genealogy** — which pipeline was mutated or crossed into which;
+  hovering an operator shows what exactly changed.
+- **The control panel** — population size, generation limit, time budget, and
+  the mutation and crossover probabilities. Changes are picked up between
+  generations; clearing a field hands the parameter back to GOLEM's adaptive
+  policy.
+- **Finish now** — not the same as Stop: the optimiser returns through its
+  normal path, FEDOT still fits the best pipeline it found, and the run ends
+  with a result and metrics.
+
+## Notes
+
+- On a headless machine set `FEDOTWEB_AUTOWATCH_BROWSER=0` — no tab opens, but
+  the run is still recorded and its URL is printed to the console.
+- Your script may exit before the server thread: the run is already persisted,
+  nothing is lost.
+- A worked example lives in `backend/examples/watch_a_script.py`; see also the
+  "Watching a run you started yourself" section of `README.v2.md`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Web interface for the FEDOT AutoML framework and the GOLEM optimiser" />
+    <title>FEDOT.Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,3303 @@
+{
+  "name": "fedot-web-ui",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fedot-web-ui",
+      "version": "2.0.0",
+      "dependencies": {
+        "@dagrejs/dagre": "^1.1.4",
+        "@emotion/react": "^11.13.5",
+        "@emotion/styled": "^11.13.5",
+        "@fontsource/inter": "^5.1.0",
+        "@fontsource/jetbrains-mono": "^5.1.1",
+        "@mui/icons-material": "^7.0.0",
+        "@mui/material": "^7.0.0",
+        "@tanstack/react-query": "^5.62.0",
+        "@xyflow/react": "^12.3.6",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.1.0",
+        "recharts": "^2.15.0",
+        "zustand": "^5.0.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.20.1",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.7.2",
+        "vite": "^6.0.5"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.8.tgz",
+      "integrity": "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "2.2.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.4.tgz",
+      "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">17.0.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+      "integrity": "sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.11.tgz",
+      "integrity": "sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.11.tgz",
+      "integrity": "sha512-+hz5ilwHZ3djd5es3sCErLioqe/NhZcYTsV/TNXZAMdJdb23F4xzJjqnnZdnurc3S1+ietcssRNqieOhPQLZ7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.3.11",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.11.tgz",
+      "integrity": "sha512-yq8bPc3LxOwKRWpcjRgDkYFmpM6aKlARfESTmOQcvLYFeJwtHte2tw6hJDrb8sk8wcvpDprHEHVaoUU0MslIkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/core-downloads-tracker": "^7.3.11",
+        "@mui/system": "^7.3.11",
+        "@mui/types": "^7.4.12",
+        "@mui/utils": "^7.3.11",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^7.3.11",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.11.tgz",
+      "integrity": "sha512-9B+YKms0fRHbNrqp9tOT/DNbNnU5gyvJ1o3qAGXfq8GmZcbJnE3At9x07Zr/o0pkhzg4aDdwXVqe4+AcgtOCPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "^7.3.11",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
+      "integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.11.tgz",
+      "integrity": "sha512-7izwGWdNawAKpBKcRlx7f2gFnAAjmASBWvMcyX4YYEeLOFsbfGRbUYGInvnAcUeql3rPxI7F9Ft4oY2OLRz44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/private-theming": "^7.3.11",
+        "@mui/styled-engine": "^7.3.10",
+        "@mui/types": "^7.4.12",
+        "@mui/utils": "^7.3.11",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
+      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.11.tgz",
+      "integrity": "sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/types": "^7.4.12",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.79",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+      "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "fedot-web-ui",
+  "private": true,
+  "version": "2.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@dagrejs/dagre": "^1.1.4",
+    "@emotion/react": "^11.13.5",
+    "@emotion/styled": "^11.13.5",
+    "@fontsource/inter": "^5.1.0",
+    "@fontsource/jetbrains-mono": "^5.1.1",
+    "@mui/icons-material": "^7.0.0",
+    "@mui/material": "^7.0.0",
+    "@tanstack/react-query": "^5.62.0",
+    "@xyflow/react": "^12.3.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.0",
+    "recharts": "^2.15.0",
+    "zustand": "^5.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.1",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5"
+  }
+}

--- a/ui/src/analysis/ObjectiveBreakdown.tsx
+++ b/ui/src/analysis/ObjectiveBreakdown.tsx
@@ -1,0 +1,236 @@
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import LinearProgress from '@mui/material/LinearProgress'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+
+import type { ObjectiveResult } from '../api/types'
+import { useAnalysis } from './useAnalysis'
+
+interface Props {
+  runUid: string
+  open: boolean
+  onClose: () => void
+}
+
+const show = (value: number | null | undefined, digits = 4): string =>
+  value === null || value === undefined ? '—' : Number(value.toFixed(digits)).toString()
+
+/**
+ * Where the objective value came from.
+ *
+ * FEDOT scores a pipeline on each cross-validation fold and averages the results;
+ * that average is the fitness evolution compares pipelines by, and the folds
+ * behind it are discarded. They are recomputed here on the same split the
+ * composer used, so the mean below is the number the run actually optimised —
+ * shown next to the spread across folds, which says how much to trust it.
+ */
+export default function ObjectiveBreakdown({ runUid, open, onClose }: Props) {
+  const theme = useTheme()
+  const { start, startError, record, isRunning, isCached } = useAnalysis(runUid, 'objective')
+
+  const result = record?.status === 'finished' ? (record.result as ObjectiveResult) : null
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle sx={{ pb: 1 }}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Box>
+            <Typography variant="h2" component="span">
+              Objective breakdown
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              How the fitness value evolution compared pipelines by was computed.
+            </Typography>
+          </Box>
+          <Box sx={{ flexGrow: 1 }} />
+          {result && isCached && (
+            <Tooltip title="Shown from an earlier run of this analysis">
+              <Chip size="small" variant="outlined" label="cached" />
+            </Tooltip>
+          )}
+          {result && <Chip size="small" variant="outlined" label={`${result.cv_folds} folds`} />}
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {!record && !isRunning && (
+          <Stack spacing={2} alignItems="flex-start">
+            <Typography variant="body2" color="text.secondary">
+              Refits the run's best pipeline on each cross-validation fold and scores it, then
+              scores it once more on the holdout. That takes as long as a handful of fits.
+            </Typography>
+            <Button variant="contained" onClick={() => start()}>
+              Compute breakdown
+            </Button>
+          </Stack>
+        )}
+
+        {isRunning && (
+          <Box sx={{ py: 3 }}>
+            <LinearProgress />
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+              Refitting the pipeline on each fold…
+            </Typography>
+          </Box>
+        )}
+
+        {startError && <Alert severity="error">{startError}</Alert>}
+        {record?.status === 'failed' && <Alert severity="error">{record.error}</Alert>}
+
+        {result && (
+          <Stack spacing={2.5}>
+            <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Fold</TableCell>
+                    <TableCell align="right">Train</TableCell>
+                    <TableCell align="right">Test</TableCell>
+                    {result.metrics.map((metric) => (
+                      <TableCell key={metric} align="right">
+                        {metric}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {result.folds.map((fold) => (
+                    <TableRow key={fold.fold}>
+                      <TableCell>{fold.fold + 1}</TableCell>
+                      {fold.failed ? (
+                        <TableCell colSpan={2 + result.metrics.length}>
+                          <Typography variant="caption" color="error">
+                            failed: {fold.error}
+                          </Typography>
+                        </TableCell>
+                      ) : (
+                        <>
+                          <TableCell align="right">{fold.train_size}</TableCell>
+                          <TableCell align="right">{fold.test_size}</TableCell>
+                          {result.metrics.map((metric) => (
+                            <TableCell
+                              key={metric}
+                              align="right"
+                              sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                            >
+                              {show(fold.readable?.[metric])}
+                            </TableCell>
+                          ))}
+                        </>
+                      )}
+                    </TableRow>
+                  ))}
+
+                  <TableRow sx={{ bgcolor: alpha(theme.palette.primary.main, 0.08) }}>
+                    <TableCell colSpan={3}>
+                      <Tooltip title="The mean over folds — this is the objective value evolution used">
+                        <Typography variant="subtitle2">mean over folds</Typography>
+                      </Tooltip>
+                    </TableCell>
+                    {result.metrics.map((metric) => {
+                      const summary = result.summary[metric]
+                      return (
+                        <TableCell
+                          key={metric}
+                          align="right"
+                          sx={{ fontFamily: '"JetBrains Mono", monospace', fontWeight: 700 }}
+                        >
+                          {show(summary?.readable_mean)}
+                        </TableCell>
+                      )
+                    })}
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell colSpan={3}>
+                      <Tooltip title="Largest minus smallest across folds — a wide spread means the score is unstable">
+                        <Typography variant="caption" color="text.secondary">
+                          spread across folds
+                        </Typography>
+                      </Tooltip>
+                    </TableCell>
+                    {result.metrics.map((metric) => (
+                      <TableCell
+                        key={metric}
+                        align="right"
+                        sx={{ fontFamily: '"JetBrains Mono", monospace', color: 'text.secondary' }}
+                      >
+                        {show(result.summary[metric]?.spread)}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+
+                  <TableRow sx={{ bgcolor: alpha(theme.palette.success.main, 0.08) }}>
+                    <TableCell colSpan={3}>
+                      <Tooltip title="Data neither evolution nor the folds ever saw">
+                        <Typography variant="subtitle2">
+                          holdout (n={result.holdout.size})
+                        </Typography>
+                      </Tooltip>
+                    </TableCell>
+                    {result.metrics.map((metric) => (
+                      <TableCell
+                        key={metric}
+                        align="right"
+                        sx={{ fontFamily: '"JetBrains Mono", monospace', fontWeight: 700 }}
+                      >
+                        {show(result.holdout.readable?.[metric])}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Paper>
+
+            {result.holdout.error && (
+              <Alert severity="warning">Holdout scoring failed: {result.holdout.error}</Alert>
+            )}
+
+            <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 0.75 }}>
+              {result.primary_metric && (
+                <Chip
+                  size="small"
+                  color="primary"
+                  label={`optimised for ${result.primary_metric}`}
+                />
+              )}
+              {result.metrics
+                .filter((metric) => metric !== result.primary_metric)
+                .map((metric) => (
+                  <Chip key={metric} size="small" variant="outlined" label={metric} />
+                ))}
+            </Stack>
+
+            <Typography variant="caption" color="text.disabled">
+              {result.note}
+            </Typography>
+          </Stack>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        {result && (
+          <Button onClick={() => start()} disabled={isRunning}>
+            Recompute
+          </Button>
+        )}
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/ui/src/analysis/SensitivityPanel.tsx
+++ b/ui/src/analysis/SensitivityPanel.tsx
@@ -1,0 +1,231 @@
+import { useMemo } from 'react'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import LinearProgress from '@mui/material/LinearProgress'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+
+import type { SensitivityEntity, SensitivityResult } from '../api/types'
+import { useAnalysis } from './useAnalysis'
+
+interface Props {
+  runUid: string
+  open: boolean
+  onClose: () => void
+}
+
+/**
+ * GOLEM reports each change as a sign-normalised score ratio, and its own
+ * optimiser applies changes at ratio > 1: above 1 means the change *improved*
+ * the objective — that part is dead weight or replaceable — and below 1 means
+ * the pipeline relies on it. Exactly -1 is GOLEM's could-not-evaluate sentinel.
+ *
+ * The backend ships the verdict as `improves`; the fallback below re-derives it
+ * for results computed before that field existed.
+ */
+const verdictOf = (entity: SensitivityEntity): boolean | null => {
+  if (typeof entity.improves === 'boolean') return entity.improves
+  if (entity.improves === null) return null
+  const value = entity.worst?.value
+  if (typeof value !== 'number' || !Number.isFinite(value) || value === -1) return null
+  return value > 1
+}
+
+const severityOf = (entity: SensitivityEntity): number => {
+  if (typeof entity.severity === 'number') return entity.severity
+  const value = entity.worst?.value
+  if (typeof value !== 'number' || !Number.isFinite(value) || value === -1) return 0
+  return Math.abs(value - 1)
+}
+
+const ratioOf = (entity: SensitivityEntity): number | null => {
+  const value = entity.worst?.value
+  return typeof value === 'number' && Number.isFinite(value) && value !== -1 ? value : null
+}
+
+export default function SensitivityPanel({ runUid, open, onClose }: Props) {
+  const theme = useTheme()
+  const { start, startError, record, isRunning, isCached } = useAnalysis(runUid, 'sensitivity')
+
+  const result = record?.status === 'finished' ? (record.result as SensitivityResult) : null
+
+  const rows = useMemo(() => {
+    if (!result) return []
+    // Biggest effect first, whichever direction it points.
+    return [...result.entities].sort((a, b) => severityOf(b) - severityOf(a))
+  }, [result])
+
+  const scale = useMemo(() => Math.max(...rows.map(severityOf), 0.01), [rows])
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle sx={{ pb: 1 }}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Box>
+            <Typography variant="h2" component="span">
+              Sensitivity
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              What the pipeline's score actually rests on.
+            </Typography>
+          </Box>
+          <Box sx={{ flexGrow: 1 }} />
+          {result && isCached && (
+            <Tooltip title="Shown from an earlier run of this analysis">
+              <Chip size="small" variant="outlined" label="cached" />
+            </Tooltip>
+          )}
+          {result && <Chip size="small" variant="outlined" label={result.metric} />}
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {!record && !isRunning && (
+          <Stack spacing={2} alignItems="flex-start">
+            <Typography variant="body2" color="text.secondary">
+              Runs GOLEM's structural analysis: each node is deleted, replaced and has its subtree
+              removed, and each edge deleted and replaced — refitting the pipeline every time. This
+              is the slowest thing here; expect it to take several times a single fit.
+            </Typography>
+            <Stack direction="row" spacing={1}>
+              <Button variant="contained" onClick={() => start({ replacements: 2 })}>
+                Analyse
+              </Button>
+              <Button onClick={() => start({ replacements: 1 })}>Quick pass</Button>
+            </Stack>
+          </Stack>
+        )}
+
+        {isRunning && (
+          <Box sx={{ py: 3 }}>
+            <LinearProgress />
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+              Refitting the pipeline for each variant…
+            </Typography>
+          </Box>
+        )}
+
+        {startError && <Alert severity="error">{startError}</Alert>}
+        {record?.status === 'failed' && <Alert severity="error">{record.error}</Alert>}
+
+        {result && rows.length === 0 && (
+          <Alert severity="info">
+            The analysis returned nothing to show — a single-node pipeline has no structure to vary.
+          </Alert>
+        )}
+
+        {result && rows.length > 0 && (
+          <Stack spacing={2}>
+            <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Part</TableCell>
+                    <TableCell>What it is</TableCell>
+                    <TableCell>Worst change</TableCell>
+                    <TableCell align="right">Score ratio</TableCell>
+                    <TableCell sx={{ width: '32%' }}>Impact</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((entity) => {
+                    const ratio = ratioOf(entity)
+                    const improves = verdictOf(entity)
+                    const severity = severityOf(entity)
+                    const colour =
+                      improves === null
+                        ? theme.palette.text.disabled
+                        : improves
+                          ? theme.palette.warning.main
+                          : theme.palette.info.main
+                    const width = Math.min(100, (severity / scale) * 100)
+                    return (
+                      <TableRow key={`${entity.entity_type}:${entity.entity}`}>
+                        <TableCell>
+                          <Chip
+                            size="small"
+                            variant="outlined"
+                            label={entity.entity_type}
+                            sx={{ height: 19, fontSize: '0.68rem' }}
+                          />
+                        </TableCell>
+                        <TableCell sx={{ fontFamily: '"JetBrains Mono", monospace', fontSize: '0.78rem' }}>
+                          {entity.operation ?? entity.entity}
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="caption" color="text.secondary">
+                            {entity.worst?.approach_name?.replace('Analyze', '') ?? '—'}
+                          </Typography>
+                        </TableCell>
+                        <TableCell align="right" sx={{ fontFamily: '"JetBrains Mono", monospace' }}>
+                          {ratio === null ? '—' : ratio.toFixed(4)}
+                        </TableCell>
+                        <TableCell>
+                          <Tooltip
+                            title={
+                              improves === null
+                                ? 'This change could not be evaluated'
+                                : improves
+                                  ? 'Changing this part improved the score — it is dead weight or replaceable'
+                                  : 'Changing this part hurt the score — the pipeline relies on it'
+                            }
+                          >
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                              <Box
+                                sx={{
+                                  height: 8,
+                                  width: `${width}%`,
+                                  minWidth: improves === null ? 0 : 3,
+                                  borderRadius: 4,
+                                  bgcolor: alpha(colour, 0.75),
+                                }}
+                              />
+                              <Typography sx={{ fontSize: '0.68rem', color: 'text.disabled' }}>
+                                {improves === null ? 'n/a' : improves ? 'change helps' : 'load-bearing'}
+                              </Typography>
+                            </Box>
+                          </Tooltip>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </Paper>
+
+            <Typography variant="caption" color="text.disabled">
+              {/* Rendered locally rather than from the payload, so results cached
+                  before the wording was corrected still read right. */}
+              Each ratio compares the changed pipeline's score to the original's, sign-normalised
+              by GOLEM: above 1 the change improved the objective, below 1 the pipeline relies on
+              that part. "Worst change" names the modification with the largest effect.
+            </Typography>
+          </Stack>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        {result && (
+          <Button onClick={() => start({ replacements: 2 })} disabled={isRunning}>
+            Recompute
+          </Button>
+        )}
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/ui/src/analysis/SensitivityPanel.tsx
+++ b/ui/src/analysis/SensitivityPanel.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -8,6 +9,7 @@ import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
 import LinearProgress from '@mui/material/LinearProgress'
+import MenuItem from '@mui/material/MenuItem'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import Table from '@mui/material/Table'
@@ -15,15 +17,20 @@ import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
+import TextField from '@mui/material/TextField'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { alpha, useTheme } from '@mui/material/styles'
 
-import type { SensitivityEntity, SensitivityResult } from '../api/types'
-import { useAnalysis } from './useAnalysis'
+import { api } from '../api/client'
+import type { PipelineGraph, SensitivityEntity, SensitivityResult } from '../api/types'
+import { useAnalysis, useStandaloneAnalysis } from './useAnalysis'
 
 interface Props {
-  runUid: string
+  /** Analyse a pipeline of this run (the run supplies the dataset). */
+  runUid?: string
+  /** Or analyse a free-standing pipeline; the user then picks the dataset. */
+  standalone?: { graph: PipelineGraph; task: string | null }
   open: boolean
   onClose: () => void
 }
@@ -57,9 +64,39 @@ const ratioOf = (entity: SensitivityEntity): number | null => {
   return typeof value === 'number' && Number.isFinite(value) && value !== -1 ? value : null
 }
 
-export default function SensitivityPanel({ runUid, open, onClose }: Props) {
+export default function SensitivityPanel({ runUid, standalone, open, onClose }: Props) {
   const theme = useTheme()
-  const { start, startError, record, isRunning, isCached } = useAnalysis(runUid, 'sensitivity')
+  // Both hooks are called to keep the hook order stable; only one is live.
+  const runAnalysis = useAnalysis(runUid ?? '', 'sensitivity')
+  const standaloneAnalysis = useStandaloneAnalysis('sensitivity')
+  const { startError, record, isRunning, isCached } = standalone ? standaloneAnalysis : runAnalysis
+
+  const [datasetUid, setDatasetUid] = useState('')
+  const { data: datasets } = useQuery({
+    queryKey: ['datasets'],
+    queryFn: api.datasets,
+    enabled: Boolean(standalone) && open,
+  })
+  const matchingDatasets = useMemo(
+    () =>
+      (datasets ?? []).filter(
+        (dataset) => !standalone?.task || !dataset.task || dataset.task === standalone.task,
+      ),
+    [datasets, standalone?.task],
+  )
+
+  const start = (options: { replacements: number }) => {
+    if (standalone) {
+      void standaloneAnalysis.start({
+        graph: standalone.graph,
+        dataset_uid: datasetUid,
+        problem: standalone.task ?? undefined,
+        replacements: options.replacements,
+      })
+    } else {
+      void runAnalysis.start(options)
+    }
+  }
 
   const result = record?.status === 'finished' ? (record.result as SensitivityResult) : null
 
@@ -101,11 +138,42 @@ export default function SensitivityPanel({ runUid, open, onClose }: Props) {
               removed, and each edge deleted and replaced — refitting the pipeline every time. This
               is the slowest thing here; expect it to take several times a single fit.
             </Typography>
+            {standalone && (
+              <TextField
+                select
+                size="small"
+                label="Dataset to fit on"
+                value={datasetUid}
+                onChange={(event) => setDatasetUid(event.target.value)}
+                helperText="The pipeline is fitted on this dataset before the analysis varies it."
+                sx={{ minWidth: 320 }}
+              >
+                {matchingDatasets.length === 0 && (
+                  <MenuItem value="" disabled>
+                    No uploaded dataset fits this task
+                  </MenuItem>
+                )}
+                {matchingDatasets.map((dataset) => (
+                  <MenuItem key={dataset.uid} value={dataset.uid}>
+                    {dataset.name} ({dataset.n_rows} rows)
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
             <Stack direction="row" spacing={1}>
-              <Button variant="contained" onClick={() => start({ replacements: 2 })}>
+              <Button
+                variant="contained"
+                onClick={() => start({ replacements: 2 })}
+                disabled={Boolean(standalone) && !datasetUid}
+              >
                 Analyse
               </Button>
-              <Button onClick={() => start({ replacements: 1 })}>Quick pass</Button>
+              <Button
+                onClick={() => start({ replacements: 1 })}
+                disabled={Boolean(standalone) && !datasetUid}
+              >
+                Quick pass
+              </Button>
             </Stack>
           </Stack>
         )}
@@ -220,7 +288,10 @@ export default function SensitivityPanel({ runUid, open, onClose }: Props) {
 
       <DialogActions>
         {result && (
-          <Button onClick={() => start({ replacements: 2 })} disabled={isRunning}>
+          <Button
+            onClick={() => start({ replacements: 2 })}
+            disabled={isRunning || (Boolean(standalone) && !datasetUid)}
+          >
             Recompute
           </Button>
         )}

--- a/ui/src/analysis/useAnalysis.ts
+++ b/ui/src/analysis/useAnalysis.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api } from '../api/client'
-import type { AnalysisKind, AnalysisRecord } from '../api/types'
+import type { AnalysisKind, AnalysisRecord, PipelineGraph } from '../api/types'
 
 /**
  * Start an analysis and follow it to completion.
@@ -29,6 +29,8 @@ export function useAnalysis(runUid: string, kind: AnalysisKind) {
     queryKey: ['analyses', runUid],
     queryFn: () => api.analyses(runUid),
     select: (all) => all.find((item) => item.kind === kind && item.status === 'finished') ?? null,
+    // The panel can be mounted without a run (editor mode); nothing to list then.
+    enabled: Boolean(runUid),
   })
 
   const start = useCallback(
@@ -58,5 +60,54 @@ export function useAnalysis(runUid: string, kind: AnalysisKind) {
     isRunning: starting || current?.status === 'running',
     /** True when what is shown came from an earlier request, not this one. */
     isCached: !uid && Boolean(previous),
+  }
+}
+
+/**
+ * The editor's variant: the pipeline belongs to no run, so the caller names the
+ * dataset to fit it on. No cache of earlier results - a drawn pipeline has no
+ * identity to look one up by.
+ */
+export function useStandaloneAnalysis(kind: AnalysisKind) {
+  const [uid, setUid] = useState<string | null>(null)
+  const [startError, setStartError] = useState<string | null>(null)
+  const [starting, setStarting] = useState(false)
+
+  const { data: record } = useQuery<AnalysisRecord>({
+    queryKey: ['analysis', uid],
+    queryFn: () => api.analysis(uid!),
+    enabled: Boolean(uid),
+    refetchInterval: (query) => (query.state.data?.status === 'running' ? 2000 : false),
+  })
+
+  const start = useCallback(
+    async (body: {
+      graph: PipelineGraph
+      dataset_uid: string
+      target?: string | null
+      problem?: string | null
+      replacements?: number
+    }) => {
+      setStarting(true)
+      setStartError(null)
+      try {
+        const started = await api.startStandaloneAnalysis({ kind, ...body })
+        setUid(started.uid)
+      } catch (error) {
+        setStartError((error as Error).message)
+      } finally {
+        setStarting(false)
+      }
+    },
+    [kind],
+  )
+
+  return {
+    start,
+    starting,
+    startError,
+    record: record ?? null,
+    isRunning: starting || record?.status === 'running',
+    isCached: false,
   }
 }

--- a/ui/src/analysis/useAnalysis.ts
+++ b/ui/src/analysis/useAnalysis.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { api } from '../api/client'
+import type { AnalysisKind, AnalysisRecord } from '../api/types'
+
+/**
+ * Start an analysis and follow it to completion.
+ *
+ * Both kinds refit the pipeline many times, so they run out of process and are
+ * polled for rather than awaited.
+ */
+export function useAnalysis(runUid: string, kind: AnalysisKind) {
+  const queryClient = useQueryClient()
+  const [uid, setUid] = useState<string | null>(null)
+  const [startError, setStartError] = useState<string | null>(null)
+  const [starting, setStarting] = useState(false)
+
+  const { data: record } = useQuery<AnalysisRecord>({
+    queryKey: ['analysis', uid],
+    queryFn: () => api.analysis(uid!),
+    enabled: Boolean(uid),
+    refetchInterval: (query) => (query.state.data?.status === 'running' ? 2000 : false),
+  })
+
+  // The most recent finished analysis of this kind, so reopening the window does
+  // not mean paying for the computation again.
+  const { data: previous } = useQuery({
+    queryKey: ['analyses', runUid],
+    queryFn: () => api.analyses(runUid),
+    select: (all) => all.find((item) => item.kind === kind && item.status === 'finished') ?? null,
+  })
+
+  const start = useCallback(
+    async (options: { replacements?: number; individual_uid?: string } = {}) => {
+      setStarting(true)
+      setStartError(null)
+      try {
+        const started = await api.startAnalysis(runUid, { kind, ...options })
+        setUid(started.uid)
+        void queryClient.invalidateQueries({ queryKey: ['analyses', runUid] })
+      } catch (error) {
+        setStartError((error as Error).message)
+      } finally {
+        setStarting(false)
+      }
+    },
+    [runUid, kind, queryClient],
+  )
+
+  const current = record ?? (uid ? null : previous)
+
+  return {
+    start,
+    starting,
+    startError,
+    record: current,
+    isRunning: starting || current?.status === 'running',
+    /** True when what is shown came from an earlier request, not this one. */
+    isCached: !uid && Boolean(previous),
+  }
+}

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1,0 +1,177 @@
+import type {
+  AnalysisKind,
+  AnalysisRecord,
+  Capabilities,
+  DatasetRecord,
+  DatasetUploadResult,
+  EvolutionControls,
+  IndividualPipeline,
+  LineageGraph,
+  OperationDetail,
+  OperationSummary,
+  PipelineGraph,
+  PipelineRecord,
+  PreprocessingReport,
+  RunConfig,
+  RunControlState,
+  RunEvent,
+  RunProgress,
+  RunRecord,
+  ValidationResult,
+} from './types'
+
+const BASE = import.meta.env.VITE_API_BASE ?? '/api'
+
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+/** Pull a useful message out of FastAPI's error shapes. */
+const errorMessage = async (response: Response): Promise<string> => {
+  try {
+    const body = await response.json()
+    const detail = body?.detail
+    if (typeof detail === 'string') return detail
+    if (Array.isArray(detail)) {
+      // Pydantic validation errors: [{loc: [...], msg: "..."}]
+      return detail
+        .map((item) => {
+          const where = Array.isArray(item?.loc) ? item.loc.slice(1).join('.') : ''
+          return where ? `${where}: ${item?.msg}` : String(item?.msg ?? item)
+        })
+        .join('; ')
+    }
+    return JSON.stringify(body)
+  } catch {
+    return response.statusText || `Request failed with status ${response.status}`
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      ...(init?.body instanceof FormData ? {} : { 'Content-Type': 'application/json' }),
+      ...init?.headers,
+    },
+  })
+
+  if (!response.ok) {
+    throw new ApiError(response.status, await errorMessage(response))
+  }
+  if (response.status === 204) {
+    return undefined as T
+  }
+  return (await response.json()) as T
+}
+
+const json = (body: unknown): RequestInit => ({ method: 'POST', body: JSON.stringify(body) })
+
+export const api = {
+  capabilities: () => request<Capabilities>('/capabilities'),
+
+  // ------------------------------------------------------------------ catalog
+  operations: (params: { task?: string; kind?: string; includeNonDefault?: boolean } = {}) => {
+    const query = new URLSearchParams()
+    if (params.task) query.set('task', params.task)
+    if (params.kind) query.set('kind', params.kind)
+    if (params.includeNonDefault === false) query.set('include_non_default', 'false')
+    const suffix = query.toString()
+    return request<OperationSummary[]>(`/operations${suffix ? `?${suffix}` : ''}`)
+  },
+  operation: (id: string) => request<OperationDetail>(`/operations/${encodeURIComponent(id)}`),
+
+  // ---------------------------------------------------------------- pipelines
+  pipelines: (runUid?: string) =>
+    request<PipelineRecord[]>(`/pipelines${runUid ? `?run_uid=${encodeURIComponent(runUid)}` : ''}`),
+  pipeline: (uid: string) => request<PipelineRecord>(`/pipelines/${uid}`),
+  savePipeline: (body: { name: string; task?: string | null; graph: PipelineGraph; uid?: string }) =>
+    request<PipelineRecord>('/pipelines', json(body)),
+  deletePipeline: (uid: string) => request<void>(`/pipelines/${uid}`, { method: 'DELETE' }),
+  validatePipeline: (graph: PipelineGraph, task?: string | null) =>
+    request<ValidationResult>('/pipelines/validate', json({ graph, task })),
+  describePipeline: (graph: PipelineGraph) =>
+    request<PipelineGraph>('/pipelines/describe', json(graph)),
+  importPipeline: (payload: unknown) => request<PipelineGraph>('/pipelines/import', json(payload)),
+  exportPipelineUrl: (uid: string) => `${BASE}/pipelines/${uid}/export`,
+
+  // ----------------------------------------------------------------- datasets
+  datasets: () => request<DatasetRecord[]>('/datasets'),
+  dataset: (uid: string) => request<DatasetRecord>(`/datasets/${uid}`),
+  datasetPreview: (uid: string) =>
+    request<{ columns: DatasetRecord['columns']; preview: Record<string, unknown>[]; n_rows: number }>(
+      `/datasets/${uid}/preview`,
+    ),
+  uploadDataset: (file: File, options: { name?: string; task?: string; target?: string } = {}) => {
+    const form = new FormData()
+    form.append('file', file)
+    if (options.name) form.append('name', options.name)
+    if (options.task) form.append('task', options.task)
+    if (options.target) form.append('target', options.target)
+    return request<DatasetUploadResult>('/datasets', { method: 'POST', body: form })
+  },
+  updateDataset: (uid: string, changes: { target?: string; task?: string }) => {
+    const form = new FormData()
+    if (changes.target) form.append('target', changes.target)
+    if (changes.task) form.append('task', changes.task)
+    return request<DatasetRecord>(`/datasets/${uid}`, { method: 'PATCH', body: form })
+  },
+  deleteDataset: (uid: string) => request<void>(`/datasets/${uid}`, { method: 'DELETE' }),
+
+  // --------------------------------------------------------------------- runs
+  runs: () => request<RunRecord[]>('/runs'),
+  run: (uid: string) => request<RunRecord>(`/runs/${uid}`),
+  startRun: (config: RunConfig, name?: string) =>
+    request<RunRecord>('/runs', json({ name, config })),
+  runProgress: (uid: string) => request<RunProgress>(`/runs/${uid}/progress`),
+  runEvents: (uid: string, afterId = 0) =>
+    request<RunEvent[]>(`/runs/${uid}/events?after_id=${afterId}`),
+  stopRun: (uid: string) => request<RunRecord>(`/runs/${uid}/stop`, { method: 'POST' }),
+  deleteRun: (uid: string) => request<void>(`/runs/${uid}`, { method: 'DELETE' }),
+
+  // ----------------------------------------------------------------- controls
+  controls: (uid: string) => request<RunControlState>(`/runs/${uid}/controls`),
+  setControls: (uid: string, patch: Partial<EvolutionControls>) =>
+    request<RunControlState>(`/runs/${uid}/controls`, {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    }),
+
+  // ----------------------------------------------------------------- analyses
+  analyses: (runUid: string) => request<AnalysisRecord[]>(`/runs/${runUid}/analyses`),
+  analysis: (uid: string) => request<AnalysisRecord>(`/analyses/${uid}`),
+  startAnalysis: (
+    runUid: string,
+    body: { kind: AnalysisKind; pipeline_uid?: string; individual_uid?: string; replacements?: number },
+  ) => request<AnalysisRecord>(`/runs/${runUid}/analyses`, json(body)),
+
+  preprocessing: (datasetUid: string, params: { task?: string; target?: string } = {}) => {
+    const query = new URLSearchParams()
+    if (params.task) query.set('task', params.task)
+    if (params.target) query.set('target', params.target)
+    const suffix = query.toString()
+    return request<PreprocessingReport>(
+      `/datasets/${datasetUid}/preprocessing${suffix ? `?${suffix}` : ''}`,
+    )
+  },
+
+  // ------------------------------------------------------------------ lineage
+  lineage: (uid: string, full = false) =>
+    request<LineageGraph>(`/runs/${uid}/lineage${full ? '?full=true' : ''}`),
+  lineagePipeline: (uid: string, individualUid: string) =>
+    request<IndividualPipeline>(`/runs/${uid}/lineage/${individualUid}`),
+}
+
+/** Open the progress socket for a run; the caller owns closing it. */
+export const openRunStream = (uid: string): WebSocket => {
+  const base = new URL(BASE, window.location.href)
+  base.protocol = base.protocol === 'https:' ? 'wss:' : 'ws:'
+  base.pathname = `${base.pathname.replace(/\/$/, '')}/runs/${uid}/stream`
+  return new WebSocket(base.toString())
+}

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -152,6 +152,15 @@ export const api = {
     runUid: string,
     body: { kind: AnalysisKind; pipeline_uid?: string; individual_uid?: string; replacements?: number },
   ) => request<AnalysisRecord>(`/runs/${runUid}/analyses`, json(body)),
+  /** Analyse a pipeline that belongs to no run, e.g. one drawn in the editor. */
+  startStandaloneAnalysis: (body: {
+    kind: AnalysisKind
+    graph: PipelineGraph
+    dataset_uid: string
+    target?: string | null
+    problem?: string | null
+    replacements?: number
+  }) => request<AnalysisRecord>('/analyses', json(body)),
 
   preprocessing: (datasetUid: string, params: { task?: string; target?: string } = {}) => {
     const query = new URLSearchParams()

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -4,6 +4,7 @@ import type {
   Capabilities,
   DatasetRecord,
   DatasetUploadResult,
+  EvaluationState,
   EvolutionControls,
   IndividualPipeline,
   LineageGraph,
@@ -130,6 +131,8 @@ export const api = {
   startRun: (config: RunConfig, name?: string) =>
     request<RunRecord>('/runs', json({ name, config })),
   runProgress: (uid: string) => request<RunProgress>(`/runs/${uid}/progress`),
+  /** What the evaluator is fitting right now: pipelines, folds, node fits. */
+  evaluations: (uid: string) => request<EvaluationState>(`/runs/${uid}/evaluations`),
   runEvents: (uid: string, afterId = 0) =>
     request<RunEvent[]>(`/runs/${uid}/events?after_id=${afterId}`),
   stopRun: (uid: string) => request<RunRecord>(`/runs/${uid}/stop`, { method: 'POST' }),

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -133,6 +133,8 @@ export const api = {
   runEvents: (uid: string, afterId = 0) =>
     request<RunEvent[]>(`/runs/${uid}/events?after_id=${afterId}`),
   stopRun: (uid: string) => request<RunRecord>(`/runs/${uid}/stop`, { method: 'POST' }),
+  /** Direct link to the saved OptHistory JSON, served as an attachment. */
+  historyUrl: (uid: string) => `${BASE}/runs/${uid}/history`,
   deleteRun: (uid: string) => request<void>(`/runs/${uid}`, { method: 'DELETE' }),
 
   // ----------------------------------------------------------------- controls

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -208,6 +208,9 @@ export interface GenerationPoint {
   mean_fitness: number | null
   worst_fitness: number | null
   elapsed?: number | null
+  /** Identity of the generation's best individual — marks leader changes. */
+  best_uid?: string | null
+  best_operations?: string[]
 }
 
 export interface RunProgress {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1,0 +1,421 @@
+/** Mirrors the pydantic models in `fedotweb/schemas.py`. */
+
+export type ParameterType =
+  | 'continuous'
+  | 'discrete'
+  | 'categorical'
+  | 'nested'
+  | 'boolean'
+  | 'free'
+
+export type ValueType = 'number' | 'integer' | 'string' | 'boolean' | 'array' | 'object'
+
+export interface NestedVariant {
+  label: string
+  fixed: Record<string, unknown>
+  options: Record<string, unknown[]>
+}
+
+/** How one hyperparameter should be presented and validated. */
+export interface ParameterSchema {
+  name: string
+  type: ParameterType
+  value_type: ValueType
+  /** True when FEDOT's tuner explores this parameter. */
+  tunable: boolean
+  distribution: string | null
+  /** The sampling scope is best traversed logarithmically. */
+  log_scale: boolean
+  default: unknown
+  minimum: number | null
+  maximum: number | null
+  choices: unknown[] | null
+  nested_variants: NestedVariant[] | null
+}
+
+export interface OperationSummary {
+  id: string
+  kind: string
+  group: string
+  family: string | null
+  description: string | null
+  tags: string[]
+  presets: string[]
+  tasks: string[]
+  input_types: string[]
+  output_types: string[]
+  allowed_positions: string[]
+  is_default: boolean
+}
+
+export interface OperationDetail extends OperationSummary {
+  parameters: ParameterSchema[]
+  defaults: Record<string, unknown>
+}
+
+export interface GraphNode {
+  id: string
+  operation: string
+  params: Record<string, unknown>
+  label?: string | null
+  kind?: string | null
+  group?: string | null
+  description?: string | null
+  tags: string[]
+  defaults: Record<string, unknown>
+  parents: string[]
+  children: string[]
+  is_primary: boolean
+  is_root: boolean
+}
+
+export interface GraphEdge {
+  id?: string | null
+  source: string
+  target: string
+}
+
+export interface PipelineGraph {
+  uid: string
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+  depth: number
+  length: number
+}
+
+export interface PipelineRecord {
+  uid: string
+  name: string
+  task: string | null
+  origin: string | null
+  run_uid: string | null
+  created_at: string
+  updated_at: string
+  length: number
+  depth: number
+  graph?: PipelineGraph | null
+}
+
+export interface ValidationResult {
+  is_valid: boolean
+  problems: string[]
+  depth: number
+  length: number
+}
+
+export interface DatasetColumn {
+  name: string
+  index: number
+  type: string
+  distinct_sample: number
+  missing_sample: number
+  examples: string[]
+}
+
+export interface DatasetRecord {
+  uid: string
+  name: string
+  filename: string
+  task: string | null
+  target: string | null
+  n_rows: number | null
+  n_columns: number | null
+  columns: DatasetColumn[]
+  created_at: string
+}
+
+export interface DatasetUploadResult extends DatasetRecord {
+  preview: Record<string, unknown>[]
+  suggested_target: string | null
+}
+
+export type Problem = 'classification' | 'regression' | 'ts_forecasting'
+
+export interface RunConfig {
+  problem: Problem
+  dataset_uid: string
+  target?: string | null
+  timeout: number
+  preset: string
+  metric?: string | null
+  seed?: number | null
+  n_jobs: number
+  cv_folds: number
+  pop_size: number
+  num_of_generations: number
+  max_depth: number
+  max_arity: number
+  with_tuning: boolean
+  early_stopping_iterations?: number | null
+  available_operations?: string[] | null
+  forecast_length: number
+  initial_pipeline?: PipelineGraph | null
+  logging_level: number
+}
+
+export type RunStatus = 'pending' | 'running' | 'finished' | 'failed' | 'cancelled'
+
+export interface RunRecord {
+  uid: string
+  name: string
+  dataset_uid: string | null
+  config: Record<string, unknown>
+  status: RunStatus
+  error: string | null
+  metrics: Record<string, number> | null
+  best_pipeline: string | null
+  created_at: string
+  started_at: string | null
+  finished_at: string | null
+}
+
+/**
+ * Knobs that can be turned while the evolution is running. `null` on a field
+ * means "leave GOLEM's own policy in charge".
+ */
+export interface EvolutionControls {
+  pop_size: number | null
+  num_of_generations: number | null
+  timeout_minutes: number | null
+  mutation_prob: number | null
+  crossover_prob: number | null
+  /** Stop after the current generation, keeping the best pipeline found so far. */
+  finish_now: boolean
+}
+
+/** What the optimiser is actually using right now. */
+export interface EffectiveParams {
+  generation: number
+  pop_size: number | null
+  mutation_prob: number | null
+  crossover_prob: number | null
+  num_of_generations: number | null
+  timeout_minutes: number | null
+  max_depth: number | null
+}
+
+export interface RunControlState {
+  requested: EvolutionControls
+  effective: EffectiveParams | null
+  can_control: boolean
+  applied: string[]
+}
+
+export interface GenerationPoint {
+  generation: number
+  size: number
+  best_fitness: number | null
+  mean_fitness: number | null
+  worst_fitness: number | null
+  elapsed?: number | null
+}
+
+export interface RunProgress {
+  run: RunRecord
+  generations: GenerationPoint[]
+  best_pipeline: PipelineGraph | null
+  last_event_id: number
+}
+
+export interface RunEvent {
+  id?: number
+  kind: string
+  payload: Record<string, unknown>
+  elapsed?: number | null
+  created_at?: string
+}
+
+/** One node of the evolution genealogy: a pipeline, or the operator that made it. */
+export interface LineageNode {
+  id: string
+  kind: 'individual' | 'operator'
+  uid: string
+  generation: number
+  /** Individuals sit on even layers, the operators that produced them on odd ones. */
+  layer: number
+  on_winning_path: boolean
+
+  // individual
+  index?: number | null
+  fitness?: number | null
+  operations: string[]
+  length?: number | null
+  native_generation?: number | null
+  is_best_in_generation: boolean
+  is_final_choice: boolean
+  /** While a run is going there is no final choice, only a leader so far. */
+  is_current_best: boolean
+
+  // operator
+  operator_type?: string | null
+  label?: string | null
+}
+
+export interface LineageEdge {
+  id: string
+  source: string
+  target: string
+  /** `survival`, `produces`, `chain`, or the operator type that created it. */
+  kind: string
+}
+
+/**
+ * One stored generation. GOLEM records the seed populations and the final choice
+ * alongside the real generations, so `is_evolutionary` separates the two.
+ */
+export interface GenerationInfo {
+  index: number
+  label: string
+  raw_label: string
+  size: number
+  is_evolutionary: boolean
+}
+
+export interface LineageGraph {
+  nodes: LineageNode[]
+  edges: LineageEdge[]
+  /** Every stored generation, including the seed and result pseudo-generations. */
+  generations: number
+  /** How many of those were actual rounds of evolution. */
+  evolution_generations: number
+  generation_meta: GenerationInfo[]
+  only_winning_path: boolean
+  truncated: boolean
+  metric_names: string[]
+  /** `history` for a finished run, `live` when assembled from progress events. */
+  source: 'history' | 'live'
+  is_live: boolean
+}
+
+export interface IndividualPipeline extends PipelineGraph {
+  fitness: number | null
+  generation: number | null
+}
+
+export type AnalysisKind = 'objective' | 'sensitivity'
+
+export interface AnalysisRecord {
+  uid: string
+  run_uid: string
+  kind: AnalysisKind
+  pipeline_uid: string | null
+  options: Record<string, unknown>
+  status: 'running' | 'finished' | 'failed'
+  error: string | null
+  result: ObjectiveResult | SensitivityResult | null
+  created_at: string
+  finished_at: string | null
+}
+
+export interface FoldResult {
+  fold: number
+  failed: boolean
+  error?: string
+  train_size?: number
+  test_size?: number
+  /** As FEDOT computes them: negated for metrics it maximises. */
+  metrics: Record<string, number | null>
+  /** The same numbers as a person reads them. */
+  readable?: Record<string, number | null>
+}
+
+export interface MetricSummary {
+  mean: number
+  readable_mean: number
+  min: number
+  max: number
+  spread: number
+  folds_used: number
+  is_maximised: boolean
+}
+
+export interface ObjectiveResult {
+  kind: 'objective'
+  problem: string
+  primary_metric: string | null
+  cv_folds: number
+  metrics: string[]
+  folds: FoldResult[]
+  summary: Record<string, MetricSummary | null>
+  holdout: {
+    size: number
+    metrics: Record<string, number | null>
+    readable: Record<string, number | null>
+    error: string | null
+  }
+  note: string
+}
+
+export interface SensitivityEntity {
+  iteration: number
+  entity_type: 'node' | 'edge'
+  entity: string
+  operation: string | null
+  approaches: Record<string, unknown>
+  worst: { entity_idx?: string; approach_name?: string; value?: number } | null
+  /**
+   * Whether the best change to this part improved the objective. GOLEM's ratio
+   * is sign-normalised, so the backend decides this once; `null` means the
+   * change could not be evaluated. Absent on results computed before this field
+   * existed.
+   */
+  improves?: boolean | null
+  /** Distance of the ratio from 1 — how much the change mattered either way. */
+  severity?: number
+}
+
+export interface SensitivityResult {
+  kind: 'sensitivity'
+  metric: string
+  is_maximised: boolean
+  entities: SensitivityEntity[]
+  note: string
+}
+
+export interface PreprocessingStep {
+  id: string
+  title: string
+  detail: string
+  columns: number[]
+  applied: boolean
+}
+
+export interface PreprocessingReport {
+  problem: string
+  target: string
+  rows: Record<string, number>
+  columns: Record<string, number>
+  source_types: Record<string, unknown>[]
+  /** Type each file column reaches the pipeline as; null where it was dropped. */
+  final_types: (string | null)[]
+  target_type: string | null
+  steps: PreprocessingStep[]
+  note: string
+}
+
+export interface TaskInfo {
+  id: string
+  label: string
+}
+
+export interface MetricInfo {
+  id: string
+  label: string
+  tasks: string[]
+}
+
+export interface PresetInfo {
+  id: string
+  label: string
+  description: string
+}
+
+export interface Capabilities {
+  fedot_version: string
+  golem_version: string | null
+  tasks: TaskInfo[]
+  metrics: MetricInfo[]
+  presets: PresetInfo[]
+  max_run_timeout_minutes: number
+  max_concurrent_runs: number
+}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -283,6 +283,8 @@ export interface LineageGraph {
   evolution_generations: number
   generation_meta: GenerationInfo[]
   only_winning_path: boolean
+  /** Winning-path view: trailing generations dropped because nothing improved in them. */
+  hidden_plateau_generations: number
   truncated: boolean
   metric_names: string[]
   /** `history` for a finished run, `live` when assembled from progress events. */

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -297,6 +297,32 @@ export interface IndividualPipeline extends PipelineGraph {
   generation: number | null
 }
 
+export interface ActiveEvaluation {
+  ops: string[]
+  /** Zero-based fold index currently being fitted, if known. */
+  fold: number | null
+  /** The operation whose fit is in progress, if any. */
+  node: string | null
+  seconds: number
+}
+
+export interface FinishedEvaluation {
+  ops: string[]
+  seconds: number | null
+  fitness: number | null
+  failed: boolean
+  error: string | null
+  finished: number | null
+}
+
+export interface EvaluationState {
+  active: ActiveEvaluation[]
+  /** A node fit outside evolution: the initial assumption or the final refit. */
+  preparing: { node: string | null; seconds: number } | null
+  recent: FinishedEvaluation[]
+  totals: { done: number; failed: number; active: number; mean_seconds: number | null }
+}
+
 export type AnalysisKind = 'objective' | 'sensitivity'
 
 export interface AnalysisRecord {

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -1,0 +1,124 @@
+import { NavLink, Outlet } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import AppBar from '@mui/material/AppBar'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Toolbar from '@mui/material/Toolbar'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+import AccountTreeRoundedIcon from '@mui/icons-material/AccountTreeRounded'
+import DarkModeRoundedIcon from '@mui/icons-material/DarkModeRounded'
+import LightModeRoundedIcon from '@mui/icons-material/LightModeRounded'
+import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded'
+import PlayCircleRoundedIcon from '@mui/icons-material/PlayCircleRounded'
+import SchemaRoundedIcon from '@mui/icons-material/SchemaRounded'
+import StorageRoundedIcon from '@mui/icons-material/StorageRounded'
+
+import { api } from '../api/client'
+import { useThemeMode } from './ThemeModeProvider'
+
+const NAV = [
+  { to: '/runs', label: 'Runs', icon: <PlayCircleRoundedIcon fontSize="small" /> },
+  { to: '/editor', label: 'Pipeline editor', icon: <SchemaRoundedIcon fontSize="small" /> },
+  { to: '/pipelines', label: 'Saved pipelines', icon: <AccountTreeRoundedIcon fontSize="small" /> },
+  { to: '/datasets', label: 'Datasets', icon: <StorageRoundedIcon fontSize="small" /> },
+]
+
+export default function AppShell() {
+  const theme = useTheme()
+  const { mode, toggle } = useThemeMode()
+  const { data: capabilities } = useQuery({
+    queryKey: ['capabilities'],
+    queryFn: api.capabilities,
+    staleTime: Infinity,
+  })
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      <AppBar
+        position="static"
+        elevation={0}
+        color="transparent"
+        sx={{
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          bgcolor: alpha(theme.palette.background.paper, 0.85),
+          backdropFilter: 'blur(8px)',
+        }}
+      >
+        <Toolbar variant="dense" sx={{ gap: 2, minHeight: 54 }}>
+          <Typography variant="h1" sx={{ fontSize: '1.05rem', mr: 1 }}>
+            FEDOT<Box component="span" sx={{ color: 'primary.main' }}>.Web</Box>
+          </Typography>
+
+          <Stack direction="row" spacing={0.5}>
+            {NAV.map((item) => (
+              <Box
+                key={item.to}
+                component={NavLink}
+                to={item.to}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  px: 1.4,
+                  py: 0.7,
+                  borderRadius: 1.5,
+                  fontSize: '0.86rem',
+                  fontWeight: 600,
+                  textDecoration: 'none',
+                  color: 'text.secondary',
+                  '&:hover': { bgcolor: alpha(theme.palette.primary.main, 0.08) },
+                  '&.active': {
+                    color: 'primary.main',
+                    bgcolor: alpha(theme.palette.primary.main, 0.13),
+                  },
+                }}
+              >
+                {item.icon}
+                {item.label}
+              </Box>
+            ))}
+          </Stack>
+
+          <Box sx={{ flexGrow: 1 }} />
+
+          {capabilities && (
+            <Stack direction="row" spacing={0.75} alignItems="center">
+              <Tooltip title="Version of the FEDOT framework this server drives">
+                <Chip size="small" variant="outlined" label={`FEDOT ${capabilities.fedot_version}`} />
+              </Tooltip>
+              {capabilities.golem_version && (
+                <Tooltip title="Version of the GOLEM optimiser used for evolution">
+                  <Chip size="small" variant="outlined" label={`GOLEM ${capabilities.golem_version}`} />
+                </Tooltip>
+              )}
+            </Stack>
+          )}
+
+          <Tooltip title="API reference">
+            <IconButton size="small" component="a" href="/docs" target="_blank" rel="noreferrer">
+              <MenuBookRoundedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={mode === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}>
+            <IconButton size="small" onClick={toggle}>
+              {mode === 'dark' ? (
+                <LightModeRoundedIcon fontSize="small" />
+              ) : (
+                <DarkModeRoundedIcon fontSize="small" />
+              )}
+            </IconButton>
+          </Tooltip>
+        </Toolbar>
+      </AppBar>
+
+      <Box sx={{ flexGrow: 1, minHeight: 0, overflow: 'hidden' }}>
+        <Outlet />
+      </Box>
+    </Box>
+  )
+}

--- a/ui/src/app/ThemeModeProvider.tsx
+++ b/ui/src/app/ThemeModeProvider.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react'
+import CssBaseline from '@mui/material/CssBaseline'
+import { ThemeProvider } from '@mui/material/styles'
+import useMediaQuery from '@mui/material/useMediaQuery'
+
+import { buildTheme } from '../theme'
+
+type Mode = 'light' | 'dark'
+
+const ThemeModeContext = createContext<{ mode: Mode; toggle: () => void }>({
+  mode: 'dark',
+  toggle: () => {},
+})
+
+export const useThemeMode = () => useContext(ThemeModeContext)
+
+const STORAGE_KEY = 'fedotweb.theme'
+
+export default function ThemeModeProvider({ children }: { children: ReactNode }) {
+  const prefersDark = useMediaQuery('(prefers-color-scheme: dark)')
+  const [stored, setStored] = useState<Mode | null>(
+    () => (localStorage.getItem(STORAGE_KEY) as Mode | null) ?? null,
+  )
+
+  const mode: Mode = stored ?? (prefersDark ? 'dark' : 'light')
+  const theme = useMemo(() => buildTheme(mode), [mode])
+
+  const value = useMemo(
+    () => ({
+      mode,
+      toggle: () => {
+        const next: Mode = mode === 'dark' ? 'light' : 'dark'
+        localStorage.setItem(STORAGE_KEY, next)
+        setStored(next)
+      },
+    }),
+    [mode],
+  )
+
+  return (
+    <ThemeModeContext.Provider value={value}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </ThemeModeContext.Provider>
+  )
+}

--- a/ui/src/datasets/PreprocessingReport.tsx
+++ b/ui/src/datasets/PreprocessingReport.tsx
@@ -1,0 +1,274 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import MenuItem from '@mui/material/MenuItem'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+import ArrowRightAltRoundedIcon from '@mui/icons-material/ArrowRightAltRounded'
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
+import RemoveCircleOutlineRoundedIcon from '@mui/icons-material/RemoveCircleOutlineRounded'
+
+import { api } from '../api/client'
+import type { DatasetRecord } from '../api/types'
+
+interface Props {
+  dataset: DatasetRecord
+}
+
+const TASKS = [
+  { id: 'classification', label: 'Classification' },
+  { id: 'regression', label: 'Regression' },
+  { id: 'ts_forecasting', label: 'Time series forecasting' },
+]
+
+/** Colours by the type a column ends up as, so the before/after reads at a glance. */
+const TYPE_COLORS: Record<string, string> = {
+  float: '#42a5f5',
+  int: '#26a69a',
+  str: '#ab47bc',
+  bool: '#ffa726',
+  NoneType: '#78909c',
+}
+
+export default function PreprocessingReport({ dataset }: Props) {
+  const theme = useTheme()
+  const [task, setTask] = useState(dataset.task ?? 'classification')
+  const [enabled, setEnabled] = useState(false)
+
+  const { data: report, isFetching, error } = useQuery({
+    queryKey: ['preprocessing', dataset.uid, task],
+    queryFn: () => api.preprocessing(dataset.uid, { task }),
+    enabled,
+    staleTime: Infinity,
+    retry: false,
+  })
+
+  const featureColumns = dataset.columns.filter((column) => column.name !== dataset.target)
+
+  // Feature order in the report is the file's column order minus the target —
+  // unless FEDOT also consumed a column as the index, in which case the counts
+  // disagree and positional names would mislabel every column after it.
+  const namesAligned = report ? report.columns.before === featureColumns.length : true
+  const nameOf = (fileIndex: number): string =>
+    namesAligned ? (featureColumns[fileIndex]?.name ?? `column ${fileIndex}`) : `column ${fileIndex}`
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mb: 1 }}>
+        <Box>
+          <Typography variant="h3">Preprocessing</Typography>
+          <Typography variant="caption" color="text.secondary">
+            What FEDOT does to this data before any pipeline sees it.
+          </Typography>
+        </Box>
+        <Box sx={{ flexGrow: 1 }} />
+        <TextField
+          select
+          size="small"
+          label="Task"
+          value={task}
+          onChange={(event) => setTask(event.target.value)}
+          sx={{ width: 200 }}
+        >
+          {TASKS.map((item) => (
+            <MenuItem key={item.id} value={item.id}>
+              {item.label}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Button variant={report ? 'text' : 'contained'} onClick={() => setEnabled(true)} disabled={isFetching}>
+          {report ? 'Refresh' : 'Analyse'}
+        </Button>
+      </Stack>
+
+      {isFetching && (
+        <Stack alignItems="center" sx={{ py: 3 }}>
+          <CircularProgress size={22} />
+        </Stack>
+      )}
+
+      {error && <Alert severity="error">{(error as Error).message}</Alert>}
+
+      {report && (
+        <Stack spacing={2}>
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 0.75 }}>
+            <Chip
+              size="small"
+              variant="outlined"
+              label={`rows ${report.rows.before} → ${report.rows.after}`}
+              color={report.rows.before === report.rows.after ? 'default' : 'warning'}
+            />
+            <Chip
+              size="small"
+              variant="outlined"
+              label={`columns ${report.columns.before} → ${report.columns.after}`}
+              color={report.columns.before === report.columns.after ? 'default' : 'warning'}
+            />
+            {report.target_type && (
+              <Chip size="small" variant="outlined" label={`target → ${report.target_type}`} />
+            )}
+          </Stack>
+
+          <Box>
+            <Typography variant="subtitle2" sx={{ mb: 0.75 }}>
+              Columns
+            </Typography>
+            <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>#</TableCell>
+                    <TableCell>Name</TableCell>
+                    <TableCell>Found in the file</TableCell>
+                    <TableCell align="right">Gaps</TableCell>
+                    <TableCell>Type the pipeline receives</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+  {report.source_types.map((column, index) => {
+                    // Rows carry their own file index; the array position is not
+                    // trustworthy once any column has been dropped.
+                    const fileIndex = Number(column.column ?? index)
+                    const found = (column.types as string[] | undefined) ?? []
+                    const final = report.final_types[fileIndex]
+                    const changed = found.length === 1 && final && found[0] !== final
+                    const name = nameOf(fileIndex)
+                    return (
+                      <TableRow key={fileIndex}>
+                        <TableCell>{fileIndex}</TableCell>
+                        <TableCell sx={{ fontFamily: '"JetBrains Mono", monospace', fontSize: '0.78rem' }}>
+                          {name}
+                        </TableCell>
+                        <TableCell>
+                          <Stack direction="row" spacing={0.5}>
+                            {found.map((type) => (
+                              <Chip
+                                key={type}
+                                size="small"
+                                label={type}
+                                sx={{
+                                  height: 19,
+                                  fontSize: '0.68rem',
+                                  bgcolor: alpha(TYPE_COLORS[type] ?? theme.palette.text.disabled, 0.16),
+                                }}
+                              />
+                            ))}
+                          </Stack>
+                        </TableCell>
+                        <TableCell align="right">
+                          {Number(column.nan_number ?? 0) > 0 ? (
+                            <Typography variant="caption" color="warning.main">
+                              {String(column.nan_number)}
+                            </Typography>
+                          ) : (
+                            <Typography variant="caption" color="text.disabled">
+                              —
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Stack direction="row" alignItems="center" spacing={0.5}>
+                            {changed && (
+                              <ArrowRightAltRoundedIcon
+                                sx={{ fontSize: 16, color: 'warning.main' }}
+                              />
+                            )}
+                            {final ? (
+                              <Chip
+                                size="small"
+                                label={final}
+                                sx={{
+                                  height: 19,
+                                  fontSize: '0.68rem',
+                                  fontWeight: changed ? 700 : 400,
+                                  bgcolor: alpha(TYPE_COLORS[final] ?? theme.palette.text.disabled, 0.22),
+                                }}
+                              />
+                            ) : (
+                              <Tooltip title="This column did not survive preprocessing">
+                                <Typography variant="caption" color="error">
+                                  dropped
+                                </Typography>
+                              </Tooltip>
+                            )}
+                          </Stack>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </Paper>
+          </Box>
+
+          <Box>
+            <Typography variant="subtitle2" sx={{ mb: 0.75 }}>
+              Decisions
+            </Typography>
+            <Stack spacing={0.5}>
+              {report.steps.map((step) => (
+                <Stack
+                  key={step.id}
+                  direction="row"
+                  spacing={1}
+                  alignItems="flex-start"
+                  sx={{
+                    px: 1.25,
+                    py: 0.75,
+                    borderRadius: 1.5,
+                    bgcolor: step.applied ? alpha(theme.palette.primary.main, 0.06) : 'transparent',
+                    opacity: step.applied ? 1 : 0.55,
+                  }}
+                >
+                  {step.applied ? (
+                    <CheckCircleRoundedIcon sx={{ fontSize: 16, color: 'primary.main', mt: 0.2 }} />
+                  ) : (
+                    <RemoveCircleOutlineRoundedIcon
+                      sx={{ fontSize: 16, color: 'text.disabled', mt: 0.2 }}
+                    />
+                  )}
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography variant="body2">{step.title}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {step.detail}
+                    </Typography>
+                    {step.applied && step.columns.length > 0 && (
+                      <Stack direction="row" spacing={0.5} sx={{ mt: 0.5, flexWrap: 'wrap', gap: 0.4 }}>
+                        {step.columns.map((column) => (
+                          <Chip
+                            key={column}
+                            size="small"
+                            variant="outlined"
+                            label={nameOf(column)}
+                            sx={{ height: 18, fontSize: '0.65rem' }}
+                          />
+                        ))}
+                      </Stack>
+                    )}
+                  </Box>
+                </Stack>
+              ))}
+            </Stack>
+          </Box>
+
+          <Typography variant="caption" color="text.disabled">
+            {report.note}
+          </Typography>
+        </Stack>
+      )}
+    </Paper>
+  )
+}

--- a/ui/src/history/EvolutionHistory.tsx
+++ b/ui/src/history/EvolutionHistory.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import Divider from '@mui/material/Divider'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Stack from '@mui/material/Stack'
+import Switch from '@mui/material/Switch'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+import EditRoundedIcon from '@mui/icons-material/EditRounded'
+
+import { ApiError, api } from '../api/client'
+import NodeInspector from '../pipeline/NodeInspector'
+import PipelineCanvas from '../pipeline/PipelineCanvas'
+import LineageCanvas from './LineageCanvas'
+import { OPERATOR_COLORS } from './LineageNodes'
+
+interface Props {
+  runUid: string
+  /** True while the composition is still going; the graph then updates live. */
+  isLive?: boolean
+  /**
+   * Bumped by the caller whenever a new generation arrives over the socket. The
+   * graph refetches on change, which is what keeps it in step with the run.
+   */
+  liveRevision?: number
+  /** Called when the user wants to keep an individual's pipeline. */
+  onOpenInEditor?: (uid: string) => void
+}
+
+function Legend({ isLive }: { isLive: boolean }) {
+  const theme = useTheme()
+  const items: { color: string; label: string; hint: string }[] = [
+    isLive
+      ? {
+          color: theme.palette.success.main,
+          label: 'best so far',
+          hint: 'The leading pipeline at this point in the run',
+        }
+      : {
+          color: theme.palette.success.main,
+          label: 'final choice',
+          hint: 'The pipeline the run returned',
+        },
+    {
+      color: theme.palette.primary.main,
+      label: 'ancestor',
+      hint: isLive ? 'On the line of descent to the leader' : 'On the line of descent to the winner',
+    },
+    { color: OPERATOR_COLORS.mutation, label: 'mutation', hint: 'Changed one pipeline into another' },
+    { color: OPERATOR_COLORS.crossover, label: 'crossover', hint: 'Combined two parents' },
+  ]
+
+  return (
+    <Stack direction="row" spacing={1.25} sx={{ flexWrap: 'wrap', gap: 0.75 }}>
+      {items.map((item) => (
+        <Tooltip key={item.label} title={item.hint}>
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            <Box
+              sx={{
+                width: 10,
+                height: 10,
+                borderRadius: '50%',
+                bgcolor: alpha(item.color, 0.3),
+                border: '1.5px solid',
+                borderColor: item.color,
+              }}
+            />
+            <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary' }}>{item.label}</Typography>
+          </Stack>
+        </Tooltip>
+      ))}
+      <Tooltip title="The same pipeline carried unchanged into the next generation">
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Box
+            sx={{
+              width: 16,
+              borderTop: '1.5px dashed',
+              borderColor: 'text.disabled',
+            }}
+          />
+          <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary' }}>survived</Typography>
+        </Stack>
+      </Tooltip>
+    </Stack>
+  )
+}
+
+/**
+ * The evolution history, drawn as a genealogy.
+ *
+ * The fitness curve on the results screen shows that the population improved.
+ * This shows how: which pipelines were crossed or mutated into which, and which
+ * of those lines survived to become the returned model.
+ */
+export default function EvolutionHistory({
+  runUid,
+  isLive = false,
+  liveRevision = 0,
+  onOpenInEditor,
+}: Props) {
+  const [showAll, setShowAll] = useState(false)
+  const [selectedUid, setSelectedUid] = useState<string | null>(null)
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
+
+  const {
+    data: lineage,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['lineage', runUid, showAll],
+    queryFn: () => api.lineage(runUid, showAll),
+    // A finished run's genealogy never changes; a live one changes every
+    // generation and is refreshed by the effect below.
+    staleTime: isLive ? 0 : Infinity,
+    retry: false,
+  })
+
+  useEffect(() => {
+    if (isLive) void refetch()
+  }, [isLive, liveRevision, refetch])
+
+  const { data: pipeline, isFetching: pipelineLoading } = useQuery({
+    queryKey: ['lineage-pipeline', runUid, selectedUid, isLive ? liveRevision : 0],
+    queryFn: () => api.lineagePipeline(runUid, selectedUid!),
+    enabled: Boolean(selectedUid),
+    staleTime: isLive ? 0 : Infinity,
+    // Keep the previous pipeline on screen while the next one loads, so the
+    // panel does not blink on every generation.
+    placeholderData: (previous) => previous,
+  })
+
+  if (isLoading) {
+    return (
+      <Stack alignItems="center" spacing={1.5} sx={{ py: 6 }}>
+        <CircularProgress size={24} />
+        {isLive && (
+          <Typography variant="caption" color="text.secondary">
+            Waiting for the first generation…
+          </Typography>
+        )}
+      </Stack>
+    )
+  }
+
+  if (error) {
+    const notFound = error instanceof ApiError && error.status === 404
+    return (
+      <Alert severity={notFound ? 'info' : 'error'} sx={{ m: 2 }}>
+        {notFound
+          ? isLive
+            ? 'No generation has been reported yet. The genealogy appears once the composer evaluates its first population.'
+            : 'This run saved no optimisation history. FEDOT skips evolution when the time budget is too small for a generation.'
+          : (error as Error).message}
+      </Alert>
+    )
+  }
+
+  if (!lineage) return null
+
+  const individuals = lineage.nodes.filter((node) => node.kind === 'individual').length
+  const operators = lineage.nodes.filter((node) => node.kind === 'operator').length
+
+  return (
+    <Stack sx={{ height: '100%', minHeight: 0 }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1.5}
+        sx={{ px: 2, py: 1.25, borderBottom: '1px solid', borderColor: 'divider', flexWrap: 'wrap', gap: 1 }}
+      >
+        <Tooltip title="GOLEM also stores the seed populations and the final choice; those rows are labelled separately and are not counted here.">
+          <Chip
+            size="small"
+            variant="outlined"
+            label={`${lineage.evolution_generations} generations`}
+          />
+        </Tooltip>
+        <Chip size="small" variant="outlined" label={`${individuals} pipelines`} />
+        <Chip size="small" variant="outlined" label={`${operators} operators`} />
+        {lineage.is_live && (
+          <Tooltip title="Assembled from the run's progress events; it grows with each generation.">
+            <Chip size="small" color="info" label="updating" />
+          </Tooltip>
+        )}
+
+        <Divider orientation="vertical" flexItem />
+        <Legend isLive={lineage.is_live} />
+
+        <Box sx={{ flexGrow: 1 }} />
+
+        <FormControlLabel
+          control={
+            <Switch size="small" checked={showAll} onChange={(event) => setShowAll(event.target.checked)} />
+          }
+          label={
+            <Tooltip
+              title={
+                lineage.is_live
+                  ? 'Include every pipeline evaluated so far, not only the ancestors of the current leader.'
+                  : 'Include every pipeline evaluated, not only the ancestors of the winner. Large runs can reach thousands of nodes.'
+              }
+            >
+              <Typography variant="body2">Whole population</Typography>
+            </Tooltip>
+          }
+        />
+      </Stack>
+
+      {lineage.truncated && (
+        <Alert severity="warning" square sx={{ borderRadius: 0, py: 0.3 }}>
+          The genealogy was truncated because this run evaluated more pipelines than the graph can
+          show. The ancestry of the winner is complete; the rest is partial.
+        </Alert>
+      )}
+
+      <Box sx={{ display: 'flex', flexGrow: 1, minHeight: 0 }}>
+        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+          <LineageCanvas
+            graph={lineage}
+            selectedUid={selectedUid}
+            onSelectIndividual={(uid, nodeId) => {
+              setSelectedUid(uid)
+              setSelectedNodeId(null)
+              void nodeId
+            }}
+          />
+        </Box>
+
+        {selectedUid && (
+          <Box
+            sx={{
+              width: 420,
+              flexShrink: 0,
+              borderLeft: '1px solid',
+              borderColor: 'divider',
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: 0,
+            }}
+          >
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1}
+              sx={{ px: 1.5, py: 1, borderBottom: '1px solid', borderColor: 'divider' }}
+            >
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="subtitle2">Selected pipeline</Typography>
+                {pipeline && (
+                  <Typography variant="caption" color="text.secondary">
+                    generation {pipeline.generation} · fitness{' '}
+                    {pipeline.fitness === null ? '—' : Number(pipeline.fitness.toFixed(5))}
+                  </Typography>
+                )}
+              </Box>
+              <Box sx={{ flexGrow: 1 }} />
+              {pipeline && onOpenInEditor && (
+                <Tooltip title="Copy this pipeline into the editor">
+                  <Button size="small" startIcon={<EditRoundedIcon />} onClick={() => onOpenInEditor(selectedUid)}>
+                    Edit
+                  </Button>
+                </Tooltip>
+              )}
+              <Button size="small" onClick={() => setSelectedUid(null)}>
+                Close
+              </Button>
+            </Stack>
+
+            {pipelineLoading && !pipeline && (
+              <Stack alignItems="center" sx={{ py: 4 }}>
+                <CircularProgress size={20} />
+              </Stack>
+            )}
+
+            {pipeline && (
+              <>
+                <Box sx={{ height: 240, borderBottom: '1px solid', borderColor: 'divider' }}>
+                  <PipelineCanvas
+                    graph={pipeline}
+                    readOnly
+                    selectedNodeId={selectedNodeId}
+                    onSelect={setSelectedNodeId}
+                  />
+                </Box>
+                <Box sx={{ flexGrow: 1, minHeight: 0 }}>
+                  {selectedNodeId ? (
+                    <NodeInspector
+                      node={pipeline.nodes.find((node) => node.id === selectedNodeId)!}
+                      onParamsChange={() => {}}
+                      onDelete={() => {}}
+                      readOnly
+                    />
+                  ) : (
+                    <Stack sx={{ height: '100%' }} alignItems="center" justifyContent="center" px={3}>
+                      <Typography variant="caption" color="text.disabled" textAlign="center">
+                        Select a node above to see the hyperparameters evolution chose for it.
+                      </Typography>
+                    </Stack>
+                  )}
+                </Box>
+              </>
+            )}
+          </Box>
+        )}
+      </Box>
+    </Stack>
+  )
+}

--- a/ui/src/history/EvolutionHistory.tsx
+++ b/ui/src/history/EvolutionHistory.tsx
@@ -186,6 +186,15 @@ export default function EvolutionHistory({
         </Tooltip>
         <Chip size="small" variant="outlined" label={`${individuals} pipelines`} />
         <Chip size="small" variant="outlined" label={`${operators} operators`} />
+        {lineage.hidden_plateau_generations > 0 && (
+          <Tooltip title="Generations after the last improvement of the best fitness are not drawn - they only repeat the same leader. Switch on 'Whole population' to see them.">
+            <Chip
+              size="small"
+              variant="outlined"
+              label={`+${lineage.hidden_plateau_generations} plateau hidden`}
+            />
+          </Tooltip>
+        )}
         {lineage.is_live && (
           <Tooltip title="Assembled from the run's progress events; it grows with each generation.">
             <Chip size="small" color="info" label="updating" />

--- a/ui/src/history/EvolutionHistory.tsx
+++ b/ui/src/history/EvolutionHistory.tsx
@@ -256,7 +256,7 @@ export default function EvolutionHistory({
                 {pipeline && (
                   <Typography variant="caption" color="text.secondary">
                     generation {pipeline.generation} · fitness{' '}
-                    {pipeline.fitness === null ? '—' : Number(pipeline.fitness.toFixed(5))}
+                    {pipeline.fitness === null ? '—' : Number(pipeline.fitness.toFixed(4))}
                   </Typography>
                 )}
               </Box>

--- a/ui/src/history/EvolutionHistory.tsx
+++ b/ui/src/history/EvolutionHistory.tsx
@@ -8,10 +8,12 @@ import CircularProgress from '@mui/material/CircularProgress'
 import Divider from '@mui/material/Divider'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Stack from '@mui/material/Stack'
+import IconButton from '@mui/material/IconButton'
 import Switch from '@mui/material/Switch'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { alpha, useTheme } from '@mui/material/styles'
+import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded'
 import EditRoundedIcon from '@mui/icons-material/EditRounded'
 
 import { ApiError, api } from '../api/client'
@@ -211,6 +213,26 @@ export default function EvolutionHistory({
             </Tooltip>
           }
         />
+
+        <Tooltip
+          title={
+            lineage.is_live
+              ? 'The OptHistory file is written when the run finishes'
+              : 'Download the raw optimisation history (OptHistory JSON)'
+          }
+        >
+          <span>
+            <IconButton
+              size="small"
+              component="a"
+              href={api.historyUrl(runUid)}
+              download={`opt_history_${runUid}.json`}
+              disabled={lineage.is_live}
+            >
+              <DownloadRoundedIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
       </Stack>
 
       {lineage.truncated && (

--- a/ui/src/history/LineageCanvas.tsx
+++ b/ui/src/history/LineageCanvas.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+  type Edge,
+  type Node,
+  type NodeMouseHandler,
+} from '@xyflow/react'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+
+import type { LineageGraph } from '../api/types'
+import {
+  LineageIndividualNode,
+  LineageOperatorNode,
+  operatorColor,
+} from './LineageNodes'
+import { layoutLineage } from './lineageLayout'
+
+const nodeTypes = {
+  lineageIndividual: LineageIndividualNode,
+  lineageOperator: LineageOperatorNode,
+  generationLane: GenerationLane,
+}
+
+/** A labelled band behind one generation's row. */
+function GenerationLane({
+  data,
+}: {
+  data: { label: string; isEvolutionary: boolean; isEmpty: boolean; emptyReason: string }
+}) {
+  const theme = useTheme()
+
+  if (data.isEmpty) {
+    // Nothing shown from this generation. Drawing the row anyway keeps the
+    // numbering continuous, so the absence reads as information rather than as a
+    // hole in the data.
+    return (
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          pl: 1,
+          pointerEvents: 'none',
+        }}
+      >
+        <Typography sx={{ fontSize: '0.62rem', color: 'text.disabled', fontWeight: 700 }}>
+          {data.label}
+        </Typography>
+        <Box sx={{ flexGrow: 1, borderTop: '1px dashed', borderColor: 'divider' }} />
+        <Typography sx={{ fontSize: '0.6rem', color: 'text.disabled', pr: 1, fontStyle: 'italic' }}>
+          {data.emptyReason}
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        borderRadius: 1,
+        // The seed populations and the final choice are not rounds of evolution,
+        // so their bands are dimmer than the generations that did the work.
+        bgcolor: alpha(theme.palette.text.primary, data.isEvolutionary ? 0.045 : 0.02),
+        border: '1px dashed',
+        borderColor: theme.palette.divider,
+        display: 'flex',
+        alignItems: 'center',
+        pl: 1,
+        pointerEvents: 'none',
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.65rem',
+          color: 'text.disabled',
+          fontWeight: data.isEvolutionary ? 700 : 500,
+          fontStyle: data.isEvolutionary ? 'normal' : 'italic',
+        }}
+      >
+        {data.label}
+      </Typography>
+    </Box>
+  )
+}
+
+interface Props {
+  graph: LineageGraph
+  selectedUid?: string | null
+  onSelectIndividual?: (uid: string, nodeId: string) => void
+}
+
+/** Extra room around the lanes so the label has somewhere to sit. */
+const LANE_PADDING = 28
+
+function Canvas({ graph, selectedUid, onSelectIndividual }: Props) {
+  const theme = useTheme()
+  const { fitView } = useReactFlow()
+
+  const layout = useMemo(
+    () =>
+      layoutLineage(
+        graph.nodes,
+        graph.edges,
+        graph.generation_meta.map((entry) => entry.index),
+      ),
+    [graph],
+  )
+
+  // Fitness is negated for maximisation objectives, so the scale is derived from
+  // the run itself rather than assumed.
+  const fitnessRange = useMemo(() => {
+    const values = graph.nodes
+      .filter((node) => node.kind === 'individual')
+      .map((node) => node.fitness)
+      .filter((value): value is number => typeof value === 'number')
+    if (values.length === 0) return null
+    return { min: Math.min(...values), max: Math.max(...values) }
+  }, [graph.nodes])
+
+  const rankOf = (fitness: number | null | undefined): number => {
+    if (typeof fitness !== 'number' || !fitnessRange) return 0
+    const { min, max } = fitnessRange
+    if (max === min) return 1
+    // Lower is better, so invert: the best fitness gets rank 1.
+    return 1 - (fitness - min) / (max - min)
+  }
+
+  const flowNodes = useMemo<Node[]>(() => {
+    const lanes: Node[] = layout.lanes.map((lane) => {
+      const info = graph.generation_meta.find((entry) => entry.index === lane.generation)
+      return {
+        id: `lane:${lane.generation}`,
+        type: 'generationLane',
+        position: { x: -LANE_PADDING, y: lane.y },
+        width: layout.width + LANE_PADDING * 2,
+        height: lane.height,
+        data: {
+          label: info?.label ?? `gen ${lane.generation}`,
+          isEvolutionary: info?.is_evolutionary ?? true,
+          isEmpty: lane.isEmpty,
+          emptyReason: graph.only_winning_path
+            ? 'no ancestors of the winner in this population'
+            : 'nothing recorded for this generation',
+        },
+        draggable: false,
+        selectable: false,
+        focusable: false,
+        zIndex: 0,
+      }
+    })
+
+    const elements: Node[] = layout.nodes.map((node) =>
+      node.kind === 'individual'
+        ? {
+            id: node.id,
+            type: 'lineageIndividual',
+            position: { x: node.x, y: node.y },
+            width: node.width,
+            height: node.height,
+            handles: node.handles,
+            zIndex: 1,
+            data: {
+              uid: node.uid,
+              generation: node.generation,
+              fitness: node.fitness ?? null,
+              operations: node.operations,
+              isBest: node.is_best_in_generation,
+              isFinal: node.is_final_choice,
+              isCurrentBest: node.is_current_best,
+              onWinningPath: node.on_winning_path,
+              rank: rankOf(node.fitness),
+              selected: node.uid === selectedUid,
+            },
+          }
+        : {
+            id: node.id,
+            type: 'lineageOperator',
+            position: { x: node.x, y: node.y },
+            width: node.width,
+            height: node.height,
+            handles: node.handles,
+            zIndex: 1,
+            data: {
+              operatorType: node.operator_type ?? 'operator',
+              label: node.label ?? '',
+              onWinningPath: node.on_winning_path,
+            },
+          },
+    )
+
+    return [...lanes, ...elements]
+  }, [layout, selectedUid, fitnessRange, graph.generation_meta, graph.only_winning_path])
+
+  const flowEdges = useMemo<Edge[]>(
+    () =>
+      graph.edges.map((edge) => {
+        const survival = edge.kind === 'survival'
+        const stroke = survival
+          ? alpha(theme.palette.text.primary, 0.28)
+          : alpha(operatorColor(edge.kind === 'produces' ? null : edge.kind), 0.85)
+        return {
+          id: edge.id,
+          source: edge.source,
+          target: edge.target,
+          type: 'smoothstep',
+          zIndex: 1,
+          style: {
+            stroke,
+            strokeWidth: survival ? 1.1 : 1.6,
+            // A carried-over individual is not a new creation; dashing it keeps
+            // the eye on the lines where something actually happened.
+            strokeDasharray: survival ? '3 3' : undefined,
+          },
+        }
+      }),
+    [graph.edges, theme],
+  )
+
+  const key = useMemo(
+    () => `${graph.nodes.length}:${graph.edges.length}:${graph.only_winning_path}`,
+    [graph],
+  )
+  useEffect(() => {
+    const timer = window.setTimeout(() => fitView({ padding: 0.12, duration: 240 }), 40)
+    return () => window.clearTimeout(timer)
+  }, [key, fitView])
+
+  const handleClick: NodeMouseHandler = (_, node) => {
+    if (node.type !== 'lineageIndividual') return
+    const uid = (node.data as { uid?: string }).uid
+    if (uid) onSelectIndividual?.(uid, node.id)
+  }
+
+  if (graph.nodes.length === 0) {
+    return (
+      <Box sx={{ height: '100%', display: 'grid', placeItems: 'center', px: 4 }}>
+        <Typography variant="body2" color="text.disabled" textAlign="center">
+          This run has no recorded genealogy — evolution did not produce a second generation.
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <ReactFlow
+      nodes={flowNodes}
+      edges={flowEdges}
+      nodeTypes={nodeTypes}
+      onNodeClick={handleClick}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable
+      minZoom={0.05}
+      maxZoom={2.5}
+      proOptions={{ hideAttribution: true }}
+      style={{ background: theme.palette.background.default }}
+    >
+      <Background variant={BackgroundVariant.Dots} gap={20} size={1} color={theme.palette.divider} />
+      <Controls showInteractive={false} />
+      <MiniMap
+        pannable
+        zoomable
+        nodeColor={(node) =>
+          node.type === 'lineageOperator'
+            ? operatorColor((node.data as { operatorType?: string }).operatorType)
+            : (node.data as { isFinal?: boolean }).isFinal
+              ? theme.palette.success.main
+              : theme.palette.primary.main
+        }
+        maskColor={alpha(theme.palette.background.default, 0.72)}
+        style={{
+          background: theme.palette.background.paper,
+          border: `1px solid ${theme.palette.divider}`,
+        }}
+      />
+    </ReactFlow>
+  )
+}
+
+export default function LineageCanvas(props: Props) {
+  const [ready, setReady] = useState(false)
+  useEffect(() => setReady(true), [])
+  if (!ready) return null
+
+  return (
+    <ReactFlowProvider>
+      <Canvas {...props} />
+    </ReactFlowProvider>
+  )
+}

--- a/ui/src/history/LineageCanvas.tsx
+++ b/ui/src/history/LineageCanvas.tsx
@@ -21,7 +21,7 @@ import {
   LineageOperatorNode,
   operatorColor,
 } from './LineageNodes'
-import { layoutLineage } from './lineageLayout'
+import { LANE_LABEL_GUTTER, layoutLineage } from './lineageLayout'
 
 const nodeTypes = {
   lineageIndividual: LineageIndividualNode,
@@ -37,6 +37,30 @@ function GenerationLane({
 }) {
   const theme = useTheme()
 
+  // The label occupies a dedicated gutter to the left of the band, right-aligned
+  // against the row it names, so cards and edges can never run underneath it.
+  const label = (
+    <Box
+      sx={{
+        width: LANE_LABEL_GUTTER - 14,
+        flexShrink: 0,
+        textAlign: 'right',
+        pr: 1.5,
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.65rem',
+          color: 'text.disabled',
+          fontWeight: data.isEvolutionary && !data.isEmpty ? 700 : 500,
+          fontStyle: data.isEvolutionary && !data.isEmpty ? 'normal' : 'italic',
+        }}
+      >
+        {data.label}
+      </Typography>
+    </Box>
+  )
+
   if (data.isEmpty) {
     // Nothing shown from this generation. Drawing the row anyway keeps the
     // numbering continuous, so the absence reads as information rather than as a
@@ -49,13 +73,10 @@ function GenerationLane({
           display: 'flex',
           alignItems: 'center',
           gap: 1,
-          pl: 1,
           pointerEvents: 'none',
         }}
       >
-        <Typography sx={{ fontSize: '0.62rem', color: 'text.disabled', fontWeight: 700 }}>
-          {data.label}
-        </Typography>
+        {label}
         <Box sx={{ flexGrow: 1, borderTop: '1px dashed', borderColor: 'divider' }} />
         <Typography sx={{ fontSize: '0.6rem', color: 'text.disabled', pr: 1, fontStyle: 'italic' }}>
           {data.emptyReason}
@@ -69,28 +90,25 @@ function GenerationLane({
       sx={{
         width: '100%',
         height: '100%',
-        borderRadius: 1,
-        // The seed populations and the final choice are not rounds of evolution,
-        // so their bands are dimmer than the generations that did the work.
-        bgcolor: alpha(theme.palette.text.primary, data.isEvolutionary ? 0.045 : 0.02),
-        border: '1px dashed',
-        borderColor: theme.palette.divider,
         display: 'flex',
         alignItems: 'center',
-        pl: 1,
         pointerEvents: 'none',
       }}
     >
-      <Typography
+      {label}
+      <Box
         sx={{
-          fontSize: '0.65rem',
-          color: 'text.disabled',
-          fontWeight: data.isEvolutionary ? 700 : 500,
-          fontStyle: data.isEvolutionary ? 'normal' : 'italic',
+          flexGrow: 1,
+          height: '100%',
+          borderRadius: 1,
+          // The seed populations and the final choice are not rounds of
+          // evolution, so their bands are dimmer than the generations that did
+          // the work.
+          bgcolor: alpha(theme.palette.text.primary, data.isEvolutionary ? 0.045 : 0.02),
+          border: '1px dashed',
+          borderColor: theme.palette.divider,
         }}
-      >
-        {data.label}
-      </Typography>
+      />
     </Box>
   )
 }
@@ -137,14 +155,56 @@ function Canvas({ graph, selectedUid, onSelectIndividual }: Props) {
     return 1 - (fitness - min) / (max - min)
   }
 
+  // What each operator actually did: the pipelines it consumed and the one it
+  // produced, so the hover card can show the change rather than just a name.
+  const operatorContext = useMemo(() => {
+    const byId = new Map(graph.nodes.map((node) => [node.id, node]))
+    const context = new Map<string, { parentOps: string[][]; childOps: string[] | null }>()
+
+    for (const node of graph.nodes) {
+      if (node.kind !== 'operator') continue
+
+      const parentOps = graph.edges
+        .filter((edge) => edge.target === node.id)
+        .map((edge) => byId.get(edge.source))
+        .filter((parent) => parent?.kind === 'individual')
+        .map((parent) => parent!.operations)
+
+      // Chained operators (crossover then mutation) hand off through `chain`
+      // edges; the produced individual hangs off the last link.
+      let cursor = node.id
+      let childOps: string[] | null = null
+      const seen = new Set<string>()
+      while (!seen.has(cursor)) {
+        seen.add(cursor)
+        const onward = graph.edges.find(
+          (edge) => edge.source === cursor && (edge.kind === 'produces' || edge.kind === 'chain'),
+        )
+        if (!onward) break
+        const target = byId.get(onward.target)
+        if (!target) break
+        if (target.kind === 'individual') {
+          childOps = target.operations
+          break
+        }
+        cursor = target.id
+      }
+
+      context.set(node.id, { parentOps, childOps })
+    }
+    return context
+  }, [graph])
+
   const flowNodes = useMemo<Node[]>(() => {
     const lanes: Node[] = layout.lanes.map((lane) => {
       const info = graph.generation_meta.find((entry) => entry.index === lane.generation)
       return {
         id: `lane:${lane.generation}`,
         type: 'generationLane',
-        position: { x: -LANE_PADDING, y: lane.y },
-        width: layout.width + LANE_PADDING * 2,
+        // The label lives in its own gutter left of the rows, so no card can
+        // ever sit on top of it.
+        position: { x: -LANE_PADDING - LANE_LABEL_GUTTER, y: lane.y },
+        width: layout.width + LANE_PADDING * 2 + LANE_LABEL_GUTTER,
         height: lane.height,
         data: {
           label: info?.label ?? `gen ${lane.generation}`,
@@ -196,12 +256,14 @@ function Canvas({ graph, selectedUid, onSelectIndividual }: Props) {
               operatorType: node.operator_type ?? 'operator',
               label: node.label ?? '',
               onWinningPath: node.on_winning_path,
+              parentOps: operatorContext.get(node.id)?.parentOps ?? [],
+              childOps: operatorContext.get(node.id)?.childOps ?? null,
             },
           },
     )
 
     return [...lanes, ...elements]
-  }, [layout, selectedUid, fitnessRange, graph.generation_meta, graph.only_winning_path])
+  }, [layout, selectedUid, fitnessRange, graph.generation_meta, graph.only_winning_path, operatorContext])
 
   const flowEdges = useMemo<Edge[]>(
     () =>
@@ -214,8 +276,11 @@ function Canvas({ graph, selectedUid, onSelectIndividual }: Props) {
           id: edge.id,
           source: edge.source,
           target: edge.target,
-          type: 'smoothstep',
-          zIndex: 1,
+          // Bezier rather than smoothstep: orthogonal edges from neighbouring
+          // sources produce coincident vertical segments that read as one line;
+          // curves separate naturally.
+          type: 'default',
+          zIndex: 0,
           style: {
             stroke,
             strokeWidth: survival ? 1.1 : 1.6,

--- a/ui/src/history/LineageNodes.tsx
+++ b/ui/src/history/LineageNodes.tsx
@@ -1,0 +1,161 @@
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+import EmojiEventsRoundedIcon from '@mui/icons-material/EmojiEventsRounded'
+import StarRoundedIcon from '@mui/icons-material/StarRounded'
+
+/** Colours for the evolutionary operators, reused by the legend. */
+export const OPERATOR_COLORS: Record<string, string> = {
+  mutation: '#f59e0b',
+  crossover: '#8b5cf6',
+  selection: '#94a3b8',
+}
+
+export const operatorColor = (type?: string | null): string =>
+  (type && OPERATOR_COLORS[type]) || '#94a3b8'
+
+export interface IndividualNodeData extends Record<string, unknown> {
+  uid: string
+  generation: number
+  fitness: number | null
+  operations: string[]
+  isBest: boolean
+  /** The run's returned pipeline; only a finished run has one. */
+  isFinal: boolean
+  /** The leader so far, while the run is still going. */
+  isCurrentBest: boolean
+  onWinningPath: boolean
+  /** Position of this individual's fitness within the run, 0 = worst, 1 = best. */
+  rank: number
+  selected: boolean
+}
+
+export interface OperatorNodeData extends Record<string, unknown> {
+  operatorType: string
+  label: string
+  onWinningPath: boolean
+}
+
+export type IndividualFlowNode = Node<IndividualNodeData, 'lineageIndividual'>
+export type OperatorFlowNode = Node<OperatorNodeData, 'lineageOperator'>
+
+const formatFitness = (value: number | null): string => {
+  if (value === null || value === undefined) return 'not evaluated'
+  return Number(value.toFixed(5)).toString()
+}
+
+/**
+ * One pipeline, at one point in the evolution.
+ *
+ * Fill intensity tracks fitness relative to the rest of the run, so the graph
+ * shows where quality is concentrated before any node is clicked.
+ */
+export function LineageIndividualNode({ data }: NodeProps<IndividualFlowNode>) {
+  const theme = useTheme()
+  const isLeader = data.isFinal || data.isCurrentBest
+  const accent = isLeader
+    ? theme.palette.success.main
+    : data.onWinningPath
+      ? theme.palette.primary.main
+      : theme.palette.text.disabled
+
+  const intensity = Number.isFinite(data.rank) ? 0.08 + data.rank * 0.26 : 0.08
+
+  return (
+    <Tooltip
+      placement="right"
+      title={
+        <Box>
+          <div>fitness {formatFitness(data.fitness)}</div>
+          <div>generation {data.generation}</div>
+          <div>{data.operations.join(' → ') || 'empty pipeline'}</div>
+          <div style={{ opacity: 0.7, marginTop: 4 }}>click to open the pipeline</div>
+        </Box>
+      }
+    >
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          px: 0.9,
+          py: 0.5,
+          borderRadius: 1.5,
+          cursor: 'pointer',
+          bgcolor: alpha(accent, intensity),
+          border: '1px solid',
+          borderColor: data.selected ? accent : alpha(accent, 0.45),
+          boxShadow: data.selected ? `0 0 0 2px ${alpha(accent, 0.4)}` : 'none',
+          opacity: data.onWinningPath ? 1 : 0.55,
+          overflow: 'hidden',
+        }}
+      >
+        <Handle type="target" position={Position.Top} style={{ opacity: 0, width: 1, height: 1 }} />
+
+        <Stack direction="row" alignItems="center" spacing={0.4}>
+          <Typography
+            sx={{ fontSize: '0.72rem', fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}
+          >
+            {formatFitness(data.fitness)}
+          </Typography>
+          <Box sx={{ flexGrow: 1 }} />
+          {data.isBest && (
+            <StarRoundedIcon sx={{ fontSize: 13, color: accent }} titleAccess="best in generation" />
+          )}
+          {isLeader && (
+            <EmojiEventsRoundedIcon
+              sx={{ fontSize: 13, color: theme.palette.success.main }}
+              titleAccess={data.isFinal ? 'final choice' : 'best so far'}
+            />
+          )}
+        </Stack>
+
+        <Typography
+          noWrap
+          sx={{
+            fontSize: '0.62rem',
+            color: 'text.secondary',
+            fontFamily: '"JetBrains Mono", monospace',
+          }}
+        >
+          {data.operations.join(' ') || '—'}
+        </Typography>
+        <Typography sx={{ fontSize: '0.58rem', color: 'text.disabled' }}>
+          {data.operations.length} node{data.operations.length === 1 ? '' : 's'}
+        </Typography>
+
+        <Handle type="source" position={Position.Bottom} style={{ opacity: 0, width: 1, height: 1 }} />
+      </Box>
+    </Tooltip>
+  )
+}
+
+/** A mutation or crossover, drawn as the junction it is. */
+export function LineageOperatorNode({ data }: NodeProps<OperatorFlowNode>) {
+  const color = operatorColor(data.operatorType)
+  const initial = (data.operatorType?.[0] ?? '?').toUpperCase()
+
+  return (
+    <Tooltip title={`${data.operatorType}: ${data.label}`} placement="right">
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          borderRadius: '50%',
+          display: 'grid',
+          placeItems: 'center',
+          bgcolor: alpha(color, 0.22),
+          border: '1.5px solid',
+          borderColor: color,
+          opacity: data.onWinningPath ? 1 : 0.5,
+        }}
+      >
+        <Handle type="target" position={Position.Top} style={{ opacity: 0, width: 1, height: 1 }} />
+        <Typography sx={{ fontSize: '0.72rem', fontWeight: 800, color }}>{initial}</Typography>
+        <Handle type="source" position={Position.Bottom} style={{ opacity: 0, width: 1, height: 1 }} />
+      </Box>
+    </Tooltip>
+  )
+}

--- a/ui/src/history/LineageNodes.tsx
+++ b/ui/src/history/LineageNodes.tsx
@@ -37,6 +37,10 @@ export interface OperatorNodeData extends Record<string, unknown> {
   operatorType: string
   label: string
   onWinningPath: boolean
+  /** Operation lists of the pipelines this operator consumed. */
+  parentOps: string[][]
+  /** Operation list of the pipeline it produced, when known. */
+  childOps: string[] | null
 }
 
 export type IndividualFlowNode = Node<IndividualNodeData, 'lineageIndividual'>
@@ -44,7 +48,7 @@ export type OperatorFlowNode = Node<OperatorNodeData, 'lineageOperator'>
 
 const formatFitness = (value: number | null): string => {
   if (value === null || value === undefined) return 'not evaluated'
-  return Number(value.toFixed(5)).toString()
+  return Number(value.toFixed(4)).toString()
 }
 
 /**
@@ -132,13 +136,73 @@ export function LineageIndividualNode({ data }: NodeProps<IndividualFlowNode>) {
   )
 }
 
+/** Multiset difference: items of `left` not covered by `right`. */
+const missingFrom = (left: string[], right: string[]): string[] => {
+  const counts = new Map<string, number>()
+  for (const item of right) counts.set(item, (counts.get(item) ?? 0) + 1)
+  const result: string[] = []
+  for (const item of left) {
+    const available = counts.get(item) ?? 0
+    if (available > 0) counts.set(item, available - 1)
+    else result.push(item)
+  }
+  return result
+}
+
+/** What one application of the operator actually did, for the hover card. */
+function describeChange(data: OperatorNodeData): { text: string; dim?: boolean }[] {
+  const child = data.childOps
+  const lines: { text: string; dim?: boolean }[] = []
+
+  for (const parent of data.parentOps) {
+    lines.push({ text: `from: ${parent.join(' → ') || '—'}` })
+  }
+  if (data.parentOps.length === 0) {
+    lines.push({ text: 'applied to the previous operator’s result', dim: true })
+  }
+  if (child) {
+    lines.push({ text: `to:   ${child.join(' → ')}` })
+  }
+
+  // A structural diff is only unambiguous with a single parent; a crossover
+  // recombines, so its parents and child are simply listed side by side.
+  if (child && data.parentOps.length === 1) {
+    const added = missingFrom(child, data.parentOps[0])
+    const removed = missingFrom(data.parentOps[0], child)
+    if (added.length || removed.length) {
+      lines.push({
+        text: [...added.map((op) => `+ ${op}`), ...removed.map((op) => `− ${op}`)].join('   '),
+      })
+    } else {
+      lines.push({ text: 'same structure — hyperparameters changed', dim: true })
+    }
+  }
+  return lines
+}
+
 /** A mutation or crossover, drawn as the junction it is. */
 export function LineageOperatorNode({ data }: NodeProps<OperatorFlowNode>) {
   const color = operatorColor(data.operatorType)
   const initial = (data.operatorType?.[0] ?? '?').toUpperCase()
+  const change = describeChange(data)
 
   return (
-    <Tooltip title={`${data.operatorType}: ${data.label}`} placement="right">
+    <Tooltip
+      placement="right"
+      title={
+        <Box sx={{ fontFamily: '"JetBrains Mono", monospace', fontSize: '0.72rem' }}>
+          <Box sx={{ fontWeight: 700, fontFamily: 'inherit' }}>
+            {data.operatorType}
+            {data.label && data.label !== data.operatorType ? ` — ${data.label}` : ''}
+          </Box>
+          {change.map((line, index) => (
+            <Box key={index} sx={{ opacity: line.dim ? 0.65 : 1, whiteSpace: 'pre-wrap' }}>
+              {line.text}
+            </Box>
+          ))}
+        </Box>
+      }
+    >
       <Box
         sx={{
           width: '100%',

--- a/ui/src/history/lineageLayout.ts
+++ b/ui/src/history/lineageLayout.ts
@@ -7,10 +7,17 @@ export const INDIVIDUAL_HEIGHT = 54
 export const OPERATOR_SIZE = 34
 
 /** Vertical distance between one generation's row and the next. */
-const LAYER_GAP = 96
+const LAYER_GAP = 110
 
 /** Horizontal distance between neighbours in the same row. */
-const COLUMN_GAP = 26
+const COLUMN_GAP = 32
+
+/**
+ * Width of the label column to the left of the rows. Labels used to sit inside
+ * the lane band, where a row wide enough to reach the left edge ran straight
+ * under them; giving them their own gutter means nodes can never overlap text.
+ */
+export const LANE_LABEL_GUTTER = 176
 
 /** Sweeps of the barycentre heuristic used to reduce edge crossings. */
 const ORDERING_PASSES = 6

--- a/ui/src/history/lineageLayout.ts
+++ b/ui/src/history/lineageLayout.ts
@@ -1,0 +1,223 @@
+import { Position, type NodeHandle } from '@xyflow/react'
+
+import type { LineageEdge, LineageNode } from '../api/types'
+
+export const INDIVIDUAL_WIDTH = 150
+export const INDIVIDUAL_HEIGHT = 54
+export const OPERATOR_SIZE = 34
+
+/** Vertical distance between one generation's row and the next. */
+const LAYER_GAP = 96
+
+/** Horizontal distance between neighbours in the same row. */
+const COLUMN_GAP = 26
+
+/** Sweeps of the barycentre heuristic used to reduce edge crossings. */
+const ORDERING_PASSES = 6
+
+export interface PositionedLineageNode extends LineageNode {
+  x: number
+  y: number
+  width: number
+  height: number
+  /** Declared so React Flow can route edges without measuring the DOM first. */
+  handles: NodeHandle[]
+}
+
+/** Generations read top to bottom, so descent enters at the top and leaves at the bottom. */
+const handlesFor = (width: number, height: number): NodeHandle[] => [
+  { type: 'target', position: Position.Top, x: width / 2, y: 0, width: 1, height: 1 },
+  { type: 'source', position: Position.Bottom, x: width / 2, y: height, width: 1, height: 1 },
+]
+
+export interface LineageLayout {
+  nodes: PositionedLineageNode[]
+  /** Row bands, one per generation, for the background lanes and labels. */
+  lanes: { generation: number; y: number; height: number; isEmpty: boolean }[]
+  width: number
+  height: number
+}
+
+/** Height of a lane whose generation contributed nothing to the shown graph. */
+const EMPTY_LANE_HEIGHT = 22
+
+const sizeOf = (node: LineageNode) =>
+  node.kind === 'operator'
+    ? { width: OPERATOR_SIZE, height: OPERATOR_SIZE }
+    : { width: INDIVIDUAL_WIDTH, height: INDIVIDUAL_HEIGHT }
+
+/**
+ * Lay the genealogy out in layers.
+ *
+ * The structure is already layered — generation `g` occupies layer `2g`, and the
+ * operators that produced generation `g` sit on layer `2g-1` — so rather than
+ * handing it to a general graph layout, the rows are placed directly and only
+ * the order *within* each row is solved for. That keeps generations perfectly
+ * aligned, which is the whole point of reading the graph top to bottom.
+ *
+ * Ordering uses the barycentre heuristic: repeatedly place each node at the mean
+ * position of its neighbours in the adjacent layer, alternating direction. It is
+ * the standard cheap way to cut edge crossings in a layered drawing.
+ */
+export function layoutLineage(
+  nodes: LineageNode[],
+  edges: LineageEdge[],
+  /**
+   * Every generation the run recorded. Generations that contributed nothing to
+   * the shown graph still get a thin empty lane, so the numbering stays
+   * continuous and "no ancestor of the winner lived here" is visible rather than
+   * looking like a gap in the data.
+   */
+  allGenerations: number[] = [],
+): LineageLayout {
+  if (nodes.length === 0) {
+    return { nodes: [], lanes: [], width: 0, height: 0 }
+  }
+
+  const byLayer = new Map<number, LineageNode[]>()
+  for (const node of nodes) {
+    const bucket = byLayer.get(node.layer) ?? []
+    bucket.push(node)
+    byLayer.set(node.layer, bucket)
+  }
+  const layers = [...byLayer.keys()].sort((a, b) => a - b)
+
+  // Start from the order the backend produced, which follows population order.
+  const order = new Map<number, string[]>()
+  for (const layer of layers) {
+    order.set(
+      layer,
+      byLayer.get(layer)!.map((node) => node.id),
+    )
+  }
+
+  const parentsOf = new Map<string, string[]>()
+  const childrenOf = new Map<string, string[]>()
+  for (const edge of edges) {
+    if (!parentsOf.has(edge.target)) parentsOf.set(edge.target, [])
+    if (!childrenOf.has(edge.source)) childrenOf.set(edge.source, [])
+    parentsOf.get(edge.target)!.push(edge.source)
+    childrenOf.get(edge.source)!.push(edge.target)
+  }
+
+  const positionInLayer = new Map<string, number>()
+  const refreshPositions = () => {
+    for (const layer of layers) {
+      order.get(layer)!.forEach((id, index) => positionInLayer.set(id, index))
+    }
+  }
+  refreshPositions()
+
+  const barycentre = (id: string, neighbours: Map<string, string[]>): number | null => {
+    const linked = neighbours.get(id) ?? []
+    const positions = linked
+      .map((other) => positionInLayer.get(other))
+      .filter((value): value is number => value !== undefined)
+    if (positions.length === 0) return null
+    return positions.reduce((sum, value) => sum + value, 0) / positions.length
+  }
+
+  for (let pass = 0; pass < ORDERING_PASSES; pass += 1) {
+    const downward = pass % 2 === 0
+    const sequence = downward ? layers : [...layers].reverse()
+    const neighbours = downward ? parentsOf : childrenOf
+
+    for (const layer of sequence) {
+      const ids = order.get(layer)!
+      const keys = new Map<string, number>()
+      ids.forEach((id, index) => {
+        // A node with no neighbour in the reference layer keeps its place.
+        keys.set(id, barycentre(id, neighbours) ?? index)
+      })
+      const sorted = [...ids].sort((a, b) => keys.get(a)! - keys.get(b)!)
+      order.set(layer, sorted)
+    }
+    refreshPositions()
+  }
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+
+  // Row widths decide the overall canvas width, so measure before placing.
+  const rowWidths = new Map<number, number>()
+  for (const layer of layers) {
+    const width = order
+      .get(layer)!
+      .reduce((total, id) => total + sizeOf(nodeById.get(id)!).width + COLUMN_GAP, -COLUMN_GAP)
+    rowWidths.set(layer, Math.max(width, 0))
+  }
+  const canvasWidth = Math.max(...rowWidths.values(), INDIVIDUAL_WIDTH)
+
+  const positioned: PositionedLineageNode[] = []
+  const laneByGeneration = new Map<number, { top: number; bottom: number }>()
+  let y = 0
+
+  // Walk generations in order, emitting the operator row that feeds each one and
+  // then the generation itself — or a placeholder when nothing from it is shown.
+  const highestGeneration = Math.max(
+    ...layers.map((layer) => Math.ceil(layer / 2)),
+    ...allGenerations,
+    0,
+  )
+  const emptyGenerations = new Set<number>()
+
+  type Row = { layer: number } | { emptyGeneration: number }
+  const rows: Row[] = []
+  for (let generation = 0; generation <= highestGeneration; generation += 1) {
+    if (byLayer.has(generation * 2 - 1)) rows.push({ layer: generation * 2 - 1 })
+    if (byLayer.has(generation * 2)) {
+      rows.push({ layer: generation * 2 })
+    } else if (allGenerations.includes(generation)) {
+      rows.push({ emptyGeneration: generation })
+      emptyGenerations.add(generation)
+    }
+  }
+
+  for (const row of rows) {
+    if ('emptyGeneration' in row) {
+      laneByGeneration.set(row.emptyGeneration, { top: y, bottom: y + EMPTY_LANE_HEIGHT })
+      y += EMPTY_LANE_HEIGHT + LAYER_GAP / 2
+      continue
+    }
+
+    const ids = order.get(row.layer)!
+    const rowHeight = Math.max(...ids.map((id) => sizeOf(nodeById.get(id)!).height))
+    let x = (canvasWidth - rowWidths.get(row.layer)!) / 2
+
+    for (const id of ids) {
+      const node = nodeById.get(id)!
+      const { width, height } = sizeOf(node)
+      positioned.push({
+        ...node,
+        x,
+        // Centre smaller nodes (the operator dots) within the row.
+        y: y + (rowHeight - height) / 2,
+        width,
+        height,
+        handles: handlesFor(width, height),
+      })
+      x += width + COLUMN_GAP
+    }
+
+    if (row.layer % 2 === 0) {
+      laneByGeneration.set(row.layer / 2, { top: y - 10, bottom: y + rowHeight + 10 })
+    }
+
+    y += rowHeight + LAYER_GAP
+  }
+
+  const lanes = [...laneByGeneration.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([generation, band]) => ({
+      generation,
+      y: band.top,
+      height: band.bottom - band.top,
+      isEmpty: emptyGenerations.has(generation),
+    }))
+
+  return {
+    nodes: positioned,
+    lanes,
+    width: canvasWidth,
+    height: Math.max(y - LAYER_GAP, 0),
+  }
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,19 @@
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+/* React Flow paints its own surface; let the MUI theme own the background. */
+.react-flow__attribution {
+  display: none;
+}
+
+.react-flow__handle {
+  transition: transform 120ms ease;
+}
+
+.react-flow__handle:hover {
+  transform: scale(1.35);
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,58 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider, createBrowserRouter, Navigate } from 'react-router-dom'
+
+import '@fontsource/inter/400.css'
+import '@fontsource/inter/500.css'
+import '@fontsource/inter/600.css'
+import '@fontsource/inter/700.css'
+import '@fontsource/jetbrains-mono/400.css'
+import '@fontsource/jetbrains-mono/700.css'
+import '@xyflow/react/dist/style.css'
+import './index.css'
+
+import AppShell from './app/AppShell'
+import ThemeModeProvider from './app/ThemeModeProvider'
+import DatasetsPage from './pages/DatasetsPage'
+import EditorPage from './pages/EditorPage'
+import PipelinesPage from './pages/PipelinesPage'
+import RunDetailPage from './pages/RunDetailPage'
+import RunsPage from './pages/RunsPage'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // The operation catalogue never changes while the server is up.
+      staleTime: 60_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+})
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppShell />,
+    children: [
+      { index: true, element: <Navigate to="/runs" replace /> },
+      { path: 'runs', element: <RunsPage /> },
+      { path: 'runs/:uid', element: <RunDetailPage /> },
+      { path: 'editor', element: <EditorPage /> },
+      { path: 'editor/:uid', element: <EditorPage /> },
+      { path: 'pipelines', element: <PipelinesPage /> },
+      { path: 'datasets', element: <DatasetsPage /> },
+    ],
+  },
+])
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <ThemeModeProvider>
+        <RouterProvider router={router} />
+      </ThemeModeProvider>
+    </QueryClientProvider>
+  </StrictMode>,
+)

--- a/ui/src/pages/DatasetsPage.tsx
+++ b/ui/src/pages/DatasetsPage.tsx
@@ -1,0 +1,241 @@
+import { useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+import MenuItem from '@mui/material/MenuItem'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import DeleteOutlineRoundedIcon from '@mui/icons-material/DeleteOutlineRounded'
+import UploadFileRoundedIcon from '@mui/icons-material/UploadFileRounded'
+
+import { api } from '../api/client'
+import type { DatasetRecord } from '../api/types'
+import PreprocessingReport from '../datasets/PreprocessingReport'
+
+const TYPE_COLORS: Record<string, 'default' | 'primary' | 'secondary' | 'warning'> = {
+  numeric: 'primary',
+  categorical: 'secondary',
+  categorical_numeric: 'secondary',
+  empty: 'warning',
+}
+
+export default function DatasetsPage() {
+  const queryClient = useQueryClient()
+  const fileInput = useRef<HTMLInputElement>(null)
+  const [selected, setSelected] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const { data: datasets = [], isLoading } = useQuery({
+    queryKey: ['datasets'],
+    queryFn: api.datasets,
+  })
+
+  const { data: preview } = useQuery({
+    queryKey: ['dataset-preview', selected],
+    queryFn: () => api.datasetPreview(selected!),
+    enabled: Boolean(selected),
+  })
+
+  const upload = useMutation({
+    mutationFn: (file: File) => api.uploadDataset(file),
+    onSuccess: (record) => {
+      queryClient.invalidateQueries({ queryKey: ['datasets'] })
+      setSelected(record.uid)
+      setError(null)
+    },
+    onError: (uploadError: Error) => setError(uploadError.message),
+  })
+
+  const updateTarget = useMutation({
+    mutationFn: ({ uid, target }: { uid: string; target: string }) =>
+      api.updateDataset(uid, { target }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['datasets'] }),
+    onError: (updateError: Error) => setError(updateError.message),
+  })
+
+  const remove = useMutation({
+    mutationFn: (uid: string) => api.deleteDataset(uid),
+    onSuccess: (_, uid) => {
+      queryClient.invalidateQueries({ queryKey: ['datasets'] })
+      if (selected === uid) setSelected(null)
+    },
+  })
+
+  const current = datasets.find((dataset) => dataset.uid === selected) ?? null
+
+  return (
+    <Box sx={{ height: '100%', overflowY: 'auto', p: 3 }}>
+      <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
+        <Typography variant="h1">Datasets</Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button
+          variant="contained"
+          startIcon={<UploadFileRoundedIcon />}
+          onClick={() => fileInput.current?.click()}
+          disabled={upload.isPending}
+        >
+          {upload.isPending ? 'Uploading…' : 'Upload CSV'}
+        </Button>
+        <input
+          ref={fileInput}
+          type="file"
+          accept=".csv,.tsv,.txt"
+          hidden
+          onChange={(event) => {
+            const file = event.target.files?.[0]
+            if (file) upload.mutate(file)
+            event.target.value = ''
+          }}
+        />
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {isLoading && <CircularProgress size={24} />}
+
+      {!isLoading && datasets.length === 0 && (
+        <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
+          <Typography color="text.secondary">
+            No datasets yet. Upload a CSV whose columns are features plus one target column.
+          </Typography>
+        </Paper>
+      )}
+
+      {datasets.length > 0 && (
+        <Paper variant="outlined" sx={{ mb: 3 }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell align="right">Rows</TableCell>
+                <TableCell align="right">Columns</TableCell>
+                <TableCell>Target</TableCell>
+                <TableCell>Uploaded</TableCell>
+                <TableCell align="right" />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {datasets.map((dataset: DatasetRecord) => (
+                <TableRow
+                  key={dataset.uid}
+                  hover
+                  selected={dataset.uid === selected}
+                  onClick={() => setSelected(dataset.uid)}
+                  sx={{ cursor: 'pointer' }}
+                >
+                  <TableCell>{dataset.name}</TableCell>
+                  <TableCell align="right">{dataset.n_rows ?? '—'}</TableCell>
+                  <TableCell align="right">{dataset.n_columns ?? '—'}</TableCell>
+                  <TableCell onClick={(event) => event.stopPropagation()}>
+                    <TextField
+                      select
+                      size="small"
+                      variant="standard"
+                      value={dataset.target ?? ''}
+                      onChange={(event) =>
+                        updateTarget.mutate({ uid: dataset.uid, target: event.target.value })
+                      }
+                      sx={{ minWidth: 120 }}
+                    >
+                      {dataset.columns.map((column) => (
+                        <MenuItem key={column.name} value={column.name}>
+                          {column.name}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="caption" color="text.secondary">
+                      {new Date(dataset.created_at).toLocaleString()}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right" onClick={(event) => event.stopPropagation()}>
+                    <Tooltip title="Delete this dataset">
+                      <IconButton size="small" onClick={() => remove.mutate(dataset.uid)}>
+                        <DeleteOutlineRoundedIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Paper>
+      )}
+
+      {current && preview && (
+        <>
+          <Typography variant="h2" sx={{ mb: 1 }}>
+            {current.name}
+          </Typography>
+          <Stack direction="row" spacing={0.75} sx={{ mb: 1.5, flexWrap: 'wrap', gap: 0.75 }}>
+            {preview.columns.map((column) => (
+              <Tooltip
+                key={column.name}
+                title={`${column.missing_sample} missing and ${column.distinct_sample} distinct values in the sampled rows`}
+              >
+                <Chip
+                  size="small"
+                  color={column.name === current.target ? 'success' : TYPE_COLORS[column.type] ?? 'default'}
+                  variant={column.name === current.target ? 'filled' : 'outlined'}
+                  label={`${column.name} · ${column.type}`}
+                />
+              </Tooltip>
+            ))}
+          </Stack>
+
+          <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  {preview.columns.map((column) => (
+                    <TableCell key={column.name} sx={{ whiteSpace: 'nowrap' }}>
+                      {column.name}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {preview.preview.map((row, index) => (
+                  <TableRow key={index}>
+                    {preview.columns.map((column) => (
+                      <TableCell
+                        key={column.name}
+                        sx={{ fontFamily: '"JetBrains Mono", monospace', fontSize: '0.75rem' }}
+                      >
+                        {String(row[column.name] ?? '')}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Paper>
+          <Typography variant="caption" color="text.disabled" sx={{ mt: 1, display: 'block' }}>
+            Showing the first {preview.preview.length} of {preview.n_rows} rows.
+          </Typography>
+
+          <Box sx={{ mt: 3 }}>
+            <PreprocessingReport dataset={current} />
+          </Box>
+        </>
+      )}
+    </Box>
+  )
+}

--- a/ui/src/pages/EditorPage.tsx
+++ b/ui/src/pages/EditorPage.tsx
@@ -21,10 +21,12 @@ import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded'
 import ErrorRoundedIcon from '@mui/icons-material/ErrorRounded'
 import NoteAddRoundedIcon from '@mui/icons-material/NoteAddRounded'
 import SaveRoundedIcon from '@mui/icons-material/SaveRounded'
+import ScienceRoundedIcon from '@mui/icons-material/ScienceRounded'
 import SwapHorizRoundedIcon from '@mui/icons-material/SwapHorizRounded'
 import SwapVertRoundedIcon from '@mui/icons-material/SwapVertRounded'
 import UploadFileRoundedIcon from '@mui/icons-material/UploadFileRounded'
 
+import SensitivityPanel from '../analysis/SensitivityPanel'
 import { api } from '../api/client'
 import type { OperationSummary } from '../api/types'
 import NodeInspector from '../pipeline/NodeInspector'
@@ -46,6 +48,7 @@ export default function EditorPage() {
   const fileInput = useRef<HTMLInputElement>(null)
 
   const [direction, setDirection] = useState<LayoutDirection>('LR')
+  const [sensitivityOpen, setSensitivityOpen] = useState(false)
   const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' | 'info' } | null>(
     null,
   )
@@ -258,6 +261,19 @@ export default function EditorPage() {
             </IconButton>
           </Tooltip>
 
+          <Tooltip title="Fit this pipeline on a dataset and measure how much the score rests on each node and edge">
+            <span>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<ScienceRoundedIcon fontSize="small" />}
+                onClick={() => setSensitivityOpen(true)}
+                disabled={graph.nodes.length === 0}
+              >
+                Sensitivity
+              </Button>
+            </span>
+          </Tooltip>
           <Button
             size="small"
             variant="outlined"
@@ -334,6 +350,12 @@ export default function EditorPage() {
           </Stack>
         )}
       </Paper>
+
+      <SensitivityPanel
+        standalone={{ graph, task }}
+        open={sensitivityOpen}
+        onClose={() => setSensitivityOpen(false)}
+      />
 
       <Snackbar
         open={Boolean(toast)}

--- a/ui/src/pages/EditorPage.tsx
+++ b/ui/src/pages/EditorPage.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Divider from '@mui/material/Divider'
+import IconButton from '@mui/material/IconButton'
+import MenuItem from '@mui/material/MenuItem'
+import Paper from '@mui/material/Paper'
+import Snackbar from '@mui/material/Snackbar'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
+import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded'
+import ErrorRoundedIcon from '@mui/icons-material/ErrorRounded'
+import NoteAddRoundedIcon from '@mui/icons-material/NoteAddRounded'
+import SaveRoundedIcon from '@mui/icons-material/SaveRounded'
+import SwapHorizRoundedIcon from '@mui/icons-material/SwapHorizRounded'
+import SwapVertRoundedIcon from '@mui/icons-material/SwapVertRounded'
+import UploadFileRoundedIcon from '@mui/icons-material/UploadFileRounded'
+
+import { api } from '../api/client'
+import type { OperationSummary } from '../api/types'
+import NodeInspector from '../pipeline/NodeInspector'
+import OperationPalette from '../pipeline/OperationPalette'
+import PipelineCanvas from '../pipeline/PipelineCanvas'
+import { useEditorStore } from '../pipeline/editorStore'
+import type { LayoutDirection } from '../pipeline/layout'
+
+const TASKS = [
+  { id: 'classification', label: 'Classification' },
+  { id: 'regression', label: 'Regression' },
+  { id: 'ts_forecasting', label: 'Time series forecasting' },
+]
+
+export default function EditorPage() {
+  const { uid } = useParams<{ uid?: string }>()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const fileInput = useRef<HTMLInputElement>(null)
+
+  const [direction, setDirection] = useState<LayoutDirection>('LR')
+  const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' | 'info' } | null>(
+    null,
+  )
+
+  const {
+    graph,
+    task,
+    name,
+    selectedNodeId,
+    validation,
+    dirty,
+    pipelineUid,
+    setGraph,
+    setTask,
+    setName,
+    setValidation,
+    select,
+    addOperation,
+    removeNode,
+    setNodeParams,
+    connect,
+    disconnect,
+    reset,
+  } = useEditorStore()
+
+  // Loading an existing pipeline into the editor.
+  const { data: stored } = useQuery({
+    queryKey: ['pipeline', uid],
+    queryFn: () => api.pipeline(uid!),
+    enabled: Boolean(uid),
+  })
+
+  useEffect(() => {
+    if (stored?.graph) {
+      setGraph(stored.graph, { name: stored.name, uid: stored.uid, clean: true })
+      if (stored.task) setTask(stored.task)
+    }
+  }, [stored, setGraph, setTask])
+
+  useEffect(() => {
+    if (!uid) reset()
+  }, [uid, reset])
+
+  const selectedNode = useMemo(
+    () => graph.nodes.find((node) => node.id === selectedNodeId) ?? null,
+    [graph.nodes, selectedNodeId],
+  )
+
+  const validate = useMutation({
+    mutationFn: () => api.validatePipeline(graph, task),
+    onSuccess: (result) => {
+      setValidation(result)
+      setToast({
+        message: result.is_valid
+          ? `Valid pipeline — depth ${result.depth}, ${result.length} nodes`
+          : result.problems[0] ?? 'The pipeline is not valid',
+        severity: result.is_valid ? 'success' : 'error',
+      })
+    },
+    onError: (error: Error) => setToast({ message: error.message, severity: 'error' }),
+  })
+
+  const save = useMutation({
+    mutationFn: () =>
+      api.savePipeline({ name, task, graph, ...(pipelineUid ? { uid: pipelineUid } : {}) }),
+    onSuccess: (record) => {
+      queryClient.invalidateQueries({ queryKey: ['pipelines'] })
+      setGraph(record.graph!, { name: record.name, uid: record.uid, clean: true })
+      setToast({ message: 'Pipeline saved', severity: 'success' })
+      if (!uid) navigate(`/editor/${record.uid}`, { replace: true })
+    },
+    onError: (error: Error) => setToast({ message: error.message, severity: 'error' }),
+  })
+
+  const handleAdd = async (operation: OperationSummary) => {
+    try {
+      // The palette summary carries no defaults; fetch them so a new node starts
+      // from exactly what FEDOT would apply.
+      const detail = await api.operation(operation.id)
+      addOperation(operation, detail.defaults)
+    } catch {
+      addOperation(operation, {})
+    }
+  }
+
+  const handleImport = async (file: File) => {
+    try {
+      const payload = JSON.parse(await file.text())
+      const imported = await api.importPipeline(payload)
+      setGraph(imported, { name: file.name.replace(/\.json$/i, ''), uid: null })
+      setToast({ message: `Imported ${imported.nodes.length} nodes`, severity: 'success' })
+    } catch (error) {
+      setToast({ message: (error as Error).message, severity: 'error' })
+    }
+  }
+
+  const problems = useMemo(() => {
+    const map: Record<string, string> = {}
+    if (!validation || validation.is_valid) return map
+    // Rule failures are pipeline-wide; mark the roots so the warning is visible.
+    for (const node of graph.nodes) {
+      if (node.is_root) map[node.id] = validation.problems[0] ?? 'Invalid pipeline'
+    }
+    return map
+  }, [validation, graph.nodes])
+
+  return (
+    <Box sx={{ display: 'flex', height: '100%', minHeight: 0 }}>
+      <Paper
+        square
+        elevation={0}
+        sx={{ width: 268, flexShrink: 0, borderRight: '1px solid', borderColor: 'divider' }}
+      >
+        <OperationPalette task={task} onAdd={handleAdd} />
+      </Paper>
+
+      <Box sx={{ flexGrow: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{ px: 1.5, py: 1, borderBottom: '1px solid', borderColor: 'divider' }}
+        >
+          <TextField
+            size="small"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            sx={{ width: 230 }}
+          />
+          <TextField
+            size="small"
+            select
+            label="Task"
+            value={task ?? ''}
+            onChange={(event) => setTask(event.target.value || null)}
+            sx={{ width: 180 }}
+          >
+            <MenuItem value="">Any</MenuItem>
+            {TASKS.map((item) => (
+              <MenuItem key={item.id} value={item.id}>
+                {item.label}
+              </MenuItem>
+            ))}
+          </TextField>
+
+          <Divider orientation="vertical" flexItem />
+
+          <Chip size="small" variant="outlined" label={`${graph.nodes.length} nodes`} />
+          <Chip size="small" variant="outlined" label={`depth ${graph.depth || '—'}`} />
+          {dirty && <Chip size="small" color="warning" variant="outlined" label="unsaved" />}
+
+          <Box sx={{ flexGrow: 1 }} />
+
+          <ToggleButtonGroup
+            size="small"
+            exclusive
+            value={direction}
+            onChange={(_, value) => value && setDirection(value)}
+          >
+            <ToggleButton value="LR">
+              <Tooltip title="Left to right">
+                <SwapHorizRoundedIcon fontSize="small" />
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton value="TB">
+              <Tooltip title="Top to bottom">
+                <SwapVertRoundedIcon fontSize="small" />
+              </Tooltip>
+            </ToggleButton>
+          </ToggleButtonGroup>
+
+          <Tooltip title="Load a pipeline saved by FEDOT">
+            <IconButton size="small" onClick={() => fileInput.current?.click()}>
+              <UploadFileRoundedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <input
+            ref={fileInput}
+            type="file"
+            accept="application/json,.json"
+            hidden
+            onChange={(event) => {
+              const file = event.target.files?.[0]
+              if (file) void handleImport(file)
+              event.target.value = ''
+            }}
+          />
+
+          {pipelineUid && (
+            <Tooltip title="Download in FEDOT's own JSON format">
+              <IconButton size="small" component="a" href={api.exportPipelineUrl(pipelineUid)}>
+                <DownloadRoundedIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+
+          <Tooltip title="Start a new pipeline">
+            <IconButton
+              size="small"
+              onClick={() => {
+                reset()
+                navigate('/editor')
+              }}
+            >
+              <NoteAddRoundedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={() => validate.mutate()}
+            disabled={graph.nodes.length === 0 || validate.isPending}
+            startIcon={
+              validation ? (
+                validation.is_valid ? (
+                  <CheckCircleRoundedIcon fontSize="small" color="success" />
+                ) : (
+                  <ErrorRoundedIcon fontSize="small" color="error" />
+                )
+              ) : undefined
+            }
+          >
+            Validate
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            startIcon={<SaveRoundedIcon fontSize="small" />}
+            onClick={() => save.mutate()}
+            disabled={graph.nodes.length === 0 || save.isPending}
+          >
+            Save
+          </Button>
+        </Stack>
+
+        {validation && !validation.is_valid && (
+          <Alert severity="error" square sx={{ borderRadius: 0, py: 0.4 }}>
+            {validation.problems.map((problem) => (
+              <div key={problem}>{problem}</div>
+            ))}
+          </Alert>
+        )}
+
+        <Box sx={{ flexGrow: 1, minHeight: 0 }}>
+          <PipelineCanvas
+            graph={graph}
+            direction={direction}
+            selectedNodeId={selectedNodeId}
+            problems={problems}
+            onSelect={select}
+            onConnect={(source, target) => {
+              const error = connect(source, target)
+              if (error) setToast({ message: error, severity: 'error' })
+            }}
+            onDisconnect={disconnect}
+            emptyHint="Pick an operation on the left to place the first node. Drag from a node's right edge to connect it to the next one."
+          />
+        </Box>
+      </Box>
+
+      <Paper
+        square
+        elevation={0}
+        sx={{ width: 372, flexShrink: 0, borderLeft: '1px solid', borderColor: 'divider' }}
+      >
+        {selectedNode ? (
+          <NodeInspector
+            node={selectedNode}
+            onParamsChange={(params) => setNodeParams(selectedNode.id, params)}
+            onDelete={() => removeNode(selectedNode.id)}
+          />
+        ) : (
+          <Stack sx={{ height: '100%' }} alignItems="center" justifyContent="center" spacing={1} px={3}>
+            <Typography variant="body2" color="text.disabled" textAlign="center">
+              Select a node to inspect and edit its hyperparameters.
+            </Typography>
+            <Typography variant="caption" color="text.disabled" textAlign="center">
+              Every parameter is rendered from the schema FEDOT publishes for that operation, bounded
+              by the same sampling scope its tuner searches.
+            </Typography>
+          </Stack>
+        )}
+      </Paper>
+
+      <Snackbar
+        open={Boolean(toast)}
+        autoHideDuration={4500}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert severity={toast.severity} onClose={() => setToast(null)} variant="filled">
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </Box>
+  )
+}

--- a/ui/src/pages/EditorPage.tsx
+++ b/ui/src/pages/EditorPage.tsx
@@ -86,7 +86,11 @@ export default function EditorPage() {
   }, [stored, setGraph, setTask])
 
   useEffect(() => {
-    if (!uid) reset()
+    // "Open in editor" sets the store first and navigates here after, so a
+    // blind reset on mount would wipe exactly what was handed over — and a
+    // route change must not destroy unsaved work either. Only a clean store
+    // is cleared.
+    if (!uid && !useEditorStore.getState().dirty) reset()
   }, [uid, reset])
 
   const selectedNode = useMemo(

--- a/ui/src/pages/PipelinesPage.tsx
+++ b/ui/src/pages/PipelinesPage.tsx
@@ -1,0 +1,127 @@
+import { useNavigate } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import AddRoundedIcon from '@mui/icons-material/AddRounded'
+import DeleteOutlineRoundedIcon from '@mui/icons-material/DeleteOutlineRounded'
+import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded'
+
+import { api } from '../api/client'
+
+export default function PipelinesPage() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const { data: pipelines = [], isLoading } = useQuery({
+    queryKey: ['pipelines'],
+    queryFn: () => api.pipelines(),
+  })
+
+  const remove = useMutation({
+    mutationFn: (uid: string) => api.deletePipeline(uid),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['pipelines'] }),
+  })
+
+  return (
+    <Box sx={{ height: '100%', overflowY: 'auto', p: 3 }}>
+      <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
+        <Box>
+          <Typography variant="h1">Saved pipelines</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Pipelines you built by hand, and the best pipeline from every finished run.
+          </Typography>
+        </Box>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={() => navigate('/editor')}>
+          New pipeline
+        </Button>
+      </Stack>
+
+      {isLoading && <CircularProgress size={24} />}
+
+      {!isLoading && pipelines.length === 0 && (
+        <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
+          <Typography color="text.secondary">
+            Nothing saved yet. Build one in the editor, or run a composition.
+          </Typography>
+        </Paper>
+      )}
+
+      {pipelines.length > 0 && (
+        <Paper variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Origin</TableCell>
+                <TableCell>Task</TableCell>
+                <TableCell align="right">Nodes</TableCell>
+                <TableCell align="right">Depth</TableCell>
+                <TableCell>Updated</TableCell>
+                <TableCell align="right" />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {pipelines.map((pipeline) => (
+                <TableRow
+                  key={pipeline.uid}
+                  hover
+                  sx={{ cursor: 'pointer' }}
+                  onClick={() => navigate(`/editor/${pipeline.uid}`)}
+                >
+                  <TableCell>{pipeline.name}</TableCell>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      color={pipeline.origin === 'automl' ? 'primary' : 'default'}
+                      label={pipeline.origin ?? 'editor'}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="caption">{pipeline.task ?? '—'}</Typography>
+                  </TableCell>
+                  <TableCell align="right">{pipeline.length}</TableCell>
+                  <TableCell align="right">{pipeline.depth}</TableCell>
+                  <TableCell>
+                    <Typography variant="caption" color="text.secondary">
+                      {new Date(pipeline.updated_at).toLocaleString()}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right" onClick={(event) => event.stopPropagation()}>
+                    <Tooltip title="Download in FEDOT's JSON format">
+                      <IconButton
+                        size="small"
+                        component="a"
+                        href={api.exportPipelineUrl(pipeline.uid)}
+                      >
+                        <DownloadRoundedIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                      <IconButton size="small" onClick={() => remove.mutate(pipeline.uid)}>
+                        <DeleteOutlineRoundedIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Paper>
+      )}
+    </Box>
+  )
+}

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -31,6 +31,7 @@ import NodeInspector from '../pipeline/NodeInspector'
 import PipelineCanvas from '../pipeline/PipelineCanvas'
 import { useEditorStore } from '../pipeline/editorStore'
 import EvolutionControlPanel from '../runs/EvolutionControlPanel'
+import EvaluationMonitor from '../runs/EvaluationMonitor'
 import FitnessChart from '../runs/FitnessChart'
 import { useRunStream } from '../runs/useRunStream'
 
@@ -175,6 +176,15 @@ export default function RunDetailPage() {
         {isLive && (
           <Grid size={12}>
             <EvolutionControlPanel runUid={run.uid} revision={generations.length} />
+          </Grid>
+        )}
+
+        {isLive && (
+          <Grid size={12}>
+            <EvaluationMonitor
+              runUid={run.uid}
+              cvFolds={typeof run.config?.cv_folds === 'number' ? run.config.cv_folds : null}
+            />
           </Grid>
         )}
 

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -1,0 +1,417 @@
+import { useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import Divider from '@mui/material/Divider'
+import Grid from '@mui/material/Grid'
+import LinearProgress from '@mui/material/LinearProgress'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Tab from '@mui/material/Tab'
+import Tabs from '@mui/material/Tabs'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded'
+import CalculateRoundedIcon from '@mui/icons-material/CalculateRounded'
+import EditRoundedIcon from '@mui/icons-material/EditRounded'
+import FiberManualRecordRoundedIcon from '@mui/icons-material/FiberManualRecordRounded'
+import ScienceRoundedIcon from '@mui/icons-material/ScienceRounded'
+import StopRoundedIcon from '@mui/icons-material/StopRounded'
+
+import { api } from '../api/client'
+import type { GenerationPoint, PipelineGraph, RunStatus } from '../api/types'
+import ObjectiveBreakdown from '../analysis/ObjectiveBreakdown'
+import SensitivityPanel from '../analysis/SensitivityPanel'
+import EvolutionHistory from '../history/EvolutionHistory'
+import NodeInspector from '../pipeline/NodeInspector'
+import PipelineCanvas from '../pipeline/PipelineCanvas'
+import { useEditorStore } from '../pipeline/editorStore'
+import EvolutionControlPanel from '../runs/EvolutionControlPanel'
+import FitnessChart from '../runs/FitnessChart'
+import { useRunStream } from '../runs/useRunStream'
+
+const LIVE: RunStatus[] = ['pending', 'running']
+
+const STATUS_COLOR: Record<string, 'default' | 'info' | 'success' | 'error' | 'warning'> = {
+  pending: 'default',
+  running: 'info',
+  finished: 'success',
+  failed: 'error',
+  cancelled: 'warning',
+}
+
+export default function RunDetailPage() {
+  const { uid } = useParams<{ uid: string }>()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const setGraph = useEditorStore((state) => state.setGraph)
+  const setTask = useEditorStore((state) => state.setTask)
+
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
+  const [tab, setTab] = useState<'pipeline' | 'history'>('pipeline')
+  const [objectiveOpen, setObjectiveOpen] = useState(false)
+  const [sensitivityOpen, setSensitivityOpen] = useState(false)
+
+  const { data: progress, isLoading } = useQuery({
+    queryKey: ['run-progress', uid],
+    queryFn: () => api.runProgress(uid!),
+    enabled: Boolean(uid),
+    refetchInterval: (query) =>
+      LIVE.includes(query.state.data?.run.status as RunStatus) ? 5000 : false,
+  })
+
+  const isLive = LIVE.includes(progress?.run.status as RunStatus)
+  const stream = useRunStream(uid, isLive)
+
+  const stop = useMutation({
+    mutationFn: () => api.stopRun(uid!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['run-progress', uid] })
+      queryClient.invalidateQueries({ queryKey: ['runs'] })
+    },
+  })
+
+  // The socket is normally ahead of the 5-second snapshot, but after a dropped
+  // connection the snapshot becomes the fresher source — without this the chart
+  // would freeze at wherever the socket died while polling kept working.
+  const generations: GenerationPoint[] = useMemo(() => {
+    const snapshot = progress?.generations ?? []
+    return stream.generations.length >= snapshot.length ? stream.generations : snapshot
+  }, [stream.generations, progress?.generations])
+
+  const bestPipeline: PipelineGraph | null =
+    progress?.best_pipeline ?? stream.bestPipeline ?? null
+
+  const selectedNode = useMemo(
+    () => bestPipeline?.nodes.find((node) => node.id === selectedNodeId) ?? null,
+    [bestPipeline, selectedNodeId],
+  )
+
+  const latest = generations[generations.length - 1]
+  const plannedGenerations = Number(progress?.run.config?.num_of_generations ?? 0)
+  const percent =
+    plannedGenerations > 0 && latest
+      ? Math.min(100, (latest.generation / plannedGenerations) * 100)
+      : null
+
+  if (isLoading) {
+    return (
+      <Stack alignItems="center" sx={{ py: 6 }}>
+        <CircularProgress size={26} />
+      </Stack>
+    )
+  }
+
+  if (!progress) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="error">This run could not be found.</Alert>
+      </Box>
+    )
+  }
+
+  const { run } = progress
+
+  return (
+    <Box sx={{ height: '100%', overflowY: 'auto', p: 3 }}>
+      <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mb: 2 }}>
+        <Button size="small" startIcon={<ArrowBackRoundedIcon />} onClick={() => navigate('/runs')}>
+          Runs
+        </Button>
+        <Divider orientation="vertical" flexItem />
+        <Typography variant="h1" sx={{ fontSize: '1.25rem' }}>
+          {run.name}
+        </Typography>
+        <Chip size="small" color={STATUS_COLOR[run.status] ?? 'default'} label={run.status} />
+        {isLive && (
+          <Tooltip title={stream.connected ? 'Streaming live progress' : 'Reconnecting…'}>
+            <Chip
+              size="small"
+              variant="outlined"
+              color={stream.connected ? 'success' : 'warning'}
+              label={stream.connected ? 'live' : 'offline'}
+            />
+          </Tooltip>
+        )}
+        <Box sx={{ flexGrow: 1 }} />
+        {isLive && (
+          <Button
+            size="small"
+            color="error"
+            variant="outlined"
+            startIcon={<StopRoundedIcon />}
+            onClick={() => stop.mutate()}
+            disabled={stop.isPending}
+          >
+            Stop
+          </Button>
+        )}
+      </Stack>
+
+      {run.error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {run.error}
+        </Alert>
+      )}
+
+      {isLive && (
+        <Box sx={{ mb: 2 }}>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+            <Typography variant="caption" color="text.secondary">
+              {stream.status ?? 'running'}
+              {latest ? ` · generation ${latest.generation}` : ''}
+              {plannedGenerations ? ` of ${plannedGenerations}` : ''}
+            </Typography>
+          </Stack>
+          <LinearProgress variant={percent === null ? 'indeterminate' : 'determinate'} value={percent ?? 0} />
+        </Box>
+      )}
+
+      <Grid container spacing={2}>
+        {isLive && (
+          <Grid size={12}>
+            <EvolutionControlPanel runUid={run.uid} revision={generations.length} />
+          </Grid>
+        )}
+
+        <Grid size={{ xs: 12, lg: 7 }}>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Typography variant="h3" sx={{ mb: 0.5 }}>
+              Evolution
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Best and mean fitness per generation; the band shows the spread across the population.
+              Lower is better, so the axis is inverted.
+            </Typography>
+            <FitnessChart generations={generations} />
+          </Paper>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 5 }}>
+          <Paper variant="outlined" sx={{ p: 2, height: '100%' }}>
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+              <Typography variant="h3">Result</Typography>
+              <Box sx={{ flexGrow: 1 }} />
+              <Tooltip title="Per-fold metrics behind the objective value, and the holdout score">
+                <span>
+                  <Button
+                    size="small"
+                    startIcon={<CalculateRoundedIcon fontSize="small" />}
+                    onClick={() => setObjectiveOpen(true)}
+                    disabled={!run.best_pipeline}
+                  >
+                    Objective
+                  </Button>
+                </span>
+              </Tooltip>
+              <Tooltip title="How much the score depends on each node and edge">
+                <span>
+                  <Button
+                    size="small"
+                    startIcon={<ScienceRoundedIcon fontSize="small" />}
+                    onClick={() => setSensitivityOpen(true)}
+                    disabled={!run.best_pipeline}
+                  >
+                    Sensitivity
+                  </Button>
+                </span>
+              </Tooltip>
+            </Stack>
+
+            {run.metrics ? (
+              <Stack spacing={0.75}>
+                {Object.entries(run.metrics).map(([metric, score]) => (
+                  <Stack key={metric} direction="row" alignItems="baseline" spacing={1}>
+                    <Typography variant="body2" sx={{ minWidth: 96, color: 'text.secondary' }}>
+                      {metric}
+                    </Typography>
+                    <Typography variant="h3" sx={{ fontFamily: '"JetBrains Mono", monospace' }}>
+                      {score}
+                    </Typography>
+                  </Stack>
+                ))}
+                <Typography variant="caption" color="text.disabled" sx={{ mt: 0.5 }}>
+                  Measured on a holdout split the composer never saw.
+                </Typography>
+              </Stack>
+            ) : (
+              <Typography variant="body2" color="text.disabled">
+                {isLive ? 'Metrics appear once the run finishes.' : 'No metrics were recorded.'}
+              </Typography>
+            )}
+
+            <Divider sx={{ my: 1.5 }} />
+
+            <Stack spacing={0.4}>
+              {[
+                ['Task', String(run.config?.problem ?? '—')],
+                ['Preset', String(run.config?.preset ?? '—')],
+                ['Time budget', `${run.config?.timeout ?? '—'} min`],
+                ['Population', String(run.config?.pop_size ?? '—')],
+                ['Generations run', String(generations.length)],
+              ].map(([label, text]) => (
+                <Stack key={label} direction="row" justifyContent="space-between">
+                  <Typography variant="caption" color="text.secondary">
+                    {label}
+                  </Typography>
+                  <Typography variant="caption">{text}</Typography>
+                </Stack>
+              ))}
+            </Stack>
+          </Paper>
+        </Grid>
+
+        <Grid size={12}>
+          <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+            <Tabs
+              value={tab}
+              onChange={(_, value) => setTab(value)}
+              sx={{ px: 1, borderBottom: '1px solid', borderColor: 'divider', minHeight: 42 }}
+            >
+              <Tab
+                label={isLive ? 'Current best pipeline' : 'Best pipeline'}
+                value="pipeline"
+                sx={{ minHeight: 42 }}
+              />
+              <Tab
+                label="Evolution history"
+                value="history"
+                sx={{ minHeight: 42 }}
+                icon={
+                  isLive ? (
+                    <FiberManualRecordRoundedIcon sx={{ fontSize: 10, color: 'info.main' }} />
+                  ) : undefined
+                }
+                iconPosition="end"
+              />
+            </Tabs>
+
+            {tab === 'history' && (
+              <Box sx={{ height: 620 }}>
+                <EvolutionHistory
+                  runUid={run.uid}
+                  isLive={isLive}
+                  liveRevision={generations.length}
+                  onOpenInEditor={async (individualUid) => {
+                    const chosen = await api.lineagePipeline(run.uid, individualUid)
+                    setGraph(chosen, { name: `${run.name} — gen ${chosen.generation}`, uid: null })
+                    if (run.config?.problem) setTask(String(run.config.problem))
+                    navigate('/editor')
+                  }}
+                />
+              </Box>
+            )}
+
+            {tab === 'pipeline' && (
+            <>
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1}
+              sx={{ px: 2, py: 1.25, borderBottom: '1px solid', borderColor: 'divider' }}
+            >
+              {bestPipeline && (
+                <>
+                  <Chip size="small" variant="outlined" label={`${bestPipeline.nodes.length} nodes`} />
+                  <Chip size="small" variant="outlined" label={`depth ${bestPipeline.depth}`} />
+                </>
+              )}
+              <Box sx={{ flexGrow: 1 }} />
+              {bestPipeline && (
+                <Button
+                  size="small"
+                  startIcon={<EditRoundedIcon />}
+                  onClick={() => {
+                    setGraph(bestPipeline, { name: `${run.name} — copy`, uid: null })
+                    if (run.config?.problem) setTask(String(run.config.problem))
+                    navigate('/editor')
+                  }}
+                >
+                  Open in editor
+                </Button>
+              )}
+            </Stack>
+
+            <Box sx={{ display: 'flex', height: 460 }}>
+              <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                <PipelineCanvas
+                  graph={bestPipeline ?? { uid: '', nodes: [], edges: [], depth: 0, length: 0 }}
+                  readOnly
+                  selectedNodeId={selectedNodeId}
+                  onSelect={setSelectedNodeId}
+                  emptyHint={
+                    isLive
+                      ? 'The best pipeline appears after the first generation is evaluated.'
+                      : 'This run produced no pipeline.'
+                  }
+                />
+              </Box>
+              {selectedNode && (
+                <Box
+                  sx={{
+                    width: 356,
+                    flexShrink: 0,
+                    borderLeft: '1px solid',
+                    borderColor: 'divider',
+                  }}
+                >
+                  <NodeInspector
+                    node={selectedNode}
+                    onParamsChange={() => {}}
+                    onDelete={() => {}}
+                    readOnly
+                  />
+                </Box>
+              )}
+            </Box>
+            </>
+            )}
+          </Paper>
+        </Grid>
+
+        {stream.logs.length > 0 && (
+          <Grid size={12}>
+            <Paper variant="outlined" sx={{ p: 2 }}>
+              <Typography variant="h3" sx={{ mb: 1 }}>
+                Log
+              </Typography>
+              <Box
+                sx={{
+                  maxHeight: 200,
+                  overflowY: 'auto',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.74rem',
+                }}
+              >
+                {stream.logs.map((entry, index) => (
+                  <Box
+                    key={index}
+                    sx={{ color: entry.level === 'error' ? 'error.main' : 'text.secondary' }}
+                  >
+                    {entry.elapsed != null ? `[${entry.elapsed.toFixed(1)}s] ` : ''}
+                    {entry.message}
+                  </Box>
+                ))}
+              </Box>
+            </Paper>
+          </Grid>
+        )}
+      </Grid>
+
+      <ObjectiveBreakdown
+        runUid={run.uid}
+        open={objectiveOpen}
+        onClose={() => setObjectiveOpen(false)}
+      />
+      <SensitivityPanel
+        runUid={run.uid}
+        open={sensitivityOpen}
+        onClose={() => setSensitivityOpen(false)}
+      />
+    </Box>
+  )
+}

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -183,10 +183,6 @@ export default function RunDetailPage() {
             <Typography variant="h3" sx={{ mb: 0.5 }}>
               Evolution
             </Typography>
-            <Typography variant="caption" color="text.secondary">
-              Best and mean fitness per generation; the band shows the spread across the population.
-              Lower is better, so the axis is inverted.
-            </Typography>
             <FitnessChart generations={generations} />
           </Paper>
         </Grid>

--- a/ui/src/pages/RunsPage.tsx
+++ b/ui/src/pages/RunsPage.tsx
@@ -1,0 +1,255 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import IconButton from '@mui/material/IconButton'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import DeleteOutlineRoundedIcon from '@mui/icons-material/DeleteOutlineRounded'
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded'
+import StopRoundedIcon from '@mui/icons-material/StopRounded'
+
+import { api } from '../api/client'
+import type { RunStatus } from '../api/types'
+import RunConfigForm, { defaultRunConfig } from '../runs/RunConfigForm'
+import { useEditorStore } from '../pipeline/editorStore'
+
+const STATUS_COLOR: Record<RunStatus, 'default' | 'info' | 'success' | 'error' | 'warning'> = {
+  pending: 'default',
+  running: 'info',
+  finished: 'success',
+  failed: 'error',
+  cancelled: 'warning',
+}
+
+export default function RunsPage() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const editorGraph = useEditorStore((state) => state.graph)
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [useEditorPipeline, setUseEditorPipeline] = useState(false)
+  const [name, setName] = useState('')
+  const [config, setConfig] = useState(defaultRunConfig())
+  const [error, setError] = useState<string | null>(null)
+
+  const { data: runs = [], isLoading } = useQuery({
+    queryKey: ['runs'],
+    queryFn: api.runs,
+    // Keep the list fresh while something is composing.
+    refetchInterval: (query) =>
+      (query.state.data ?? []).some((run) => run.status === 'running' || run.status === 'pending')
+        ? 3000
+        : false,
+  })
+
+  const start = useMutation({
+    mutationFn: () =>
+      api.startRun(
+        {
+          ...config,
+          initial_pipeline: useEditorPipeline && editorGraph.nodes.length ? editorGraph : null,
+        },
+        name || undefined,
+      ),
+    onSuccess: (run) => {
+      queryClient.invalidateQueries({ queryKey: ['runs'] })
+      setDialogOpen(false)
+      navigate(`/runs/${run.uid}`)
+    },
+    onError: (startError: Error) => setError(startError.message),
+  })
+
+  const stop = useMutation({
+    mutationFn: (uid: string) => api.stopRun(uid),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['runs'] }),
+    onError: (stopError: Error) => setError(stopError.message),
+  })
+
+  const remove = useMutation({
+    mutationFn: (uid: string) => api.deleteRun(uid),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['runs'] }),
+    onError: (removeError: Error) => setError(removeError.message),
+  })
+
+  return (
+    <Box sx={{ height: '100%', overflowY: 'auto', p: 3 }}>
+      <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
+        <Box>
+          <Typography variant="h1">AutoML runs</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Configure and launch FEDOT compositions, and watch the evolution as it happens.
+          </Typography>
+        </Box>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button
+          variant="contained"
+          startIcon={<PlayArrowRoundedIcon />}
+          onClick={() => {
+            setError(null)
+            setUseEditorPipeline(false)
+            setDialogOpen(true)
+          }}
+        >
+          New run
+        </Button>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {isLoading && <CircularProgress size={24} />}
+
+      {!isLoading && runs.length === 0 && (
+        <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
+          <Typography color="text.secondary">
+            No runs yet. Upload a dataset, then start a composition.
+          </Typography>
+        </Paper>
+      )}
+
+      {runs.length > 0 && (
+        <Paper variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Run</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Task</TableCell>
+                <TableCell>Metrics</TableCell>
+                <TableCell>Started</TableCell>
+                <TableCell align="right" />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {runs.map((run) => (
+                <TableRow
+                  key={run.uid}
+                  hover
+                  sx={{ cursor: 'pointer' }}
+                  onClick={() => navigate(`/runs/${run.uid}`)}
+                >
+                  <TableCell>
+                    <Typography variant="body2">{run.name}</Typography>
+                    {run.error && (
+                      <Typography variant="caption" color="error" noWrap sx={{ maxWidth: 320, display: 'block' }}>
+                        {run.error}
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Chip size="small" color={STATUS_COLOR[run.status]} label={run.status} />
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="caption">{String(run.config?.problem ?? '—')}</Typography>
+                  </TableCell>
+                  <TableCell>
+                    {run.metrics ? (
+                      <Stack direction="row" spacing={0.5} sx={{ flexWrap: 'wrap', gap: 0.5 }}>
+                        {Object.entries(run.metrics).map(([metric, score]) => (
+                          <Chip
+                            key={metric}
+                            size="small"
+                            variant="outlined"
+                            label={`${metric} ${score}`}
+                            sx={{ height: 19, fontSize: '0.68rem' }}
+                          />
+                        ))}
+                      </Stack>
+                    ) : (
+                      <Typography variant="caption" color="text.disabled">
+                        —
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="caption" color="text.secondary">
+                      {run.started_at ? new Date(run.started_at).toLocaleString() : '—'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right" onClick={(event) => event.stopPropagation()}>
+                    {(run.status === 'running' || run.status === 'pending') && (
+                      <Tooltip title="Stop this run">
+                        <IconButton size="small" onClick={() => stop.mutate(run.uid)}>
+                          <StopRoundedIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                    {run.status !== 'running' && run.status !== 'pending' && (
+                      <Tooltip title="Delete this run">
+                        <IconButton size="small" onClick={() => remove.mutate(run.uid)}>
+                          <DeleteOutlineRoundedIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Paper>
+      )}
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="md" fullWidth>
+        <DialogTitle>New AutoML run</DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={2}>
+            <TextField
+              size="small"
+              fullWidth
+              label="Run name"
+              placeholder="Optional"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+            />
+            <RunConfigForm
+              value={config}
+              onChange={setConfig}
+              initialPipeline={useEditorPipeline ? editorGraph : null}
+            />
+            {editorGraph.nodes.length > 0 && (
+              <Button
+                size="small"
+                variant={useEditorPipeline ? 'contained' : 'outlined'}
+                onClick={() => setUseEditorPipeline((state) => !state)}
+                sx={{ alignSelf: 'flex-start' }}
+              >
+                {useEditorPipeline ? 'Using the editor pipeline as the starting point' : 'Start from the pipeline in the editor'}
+              </Button>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={() => start.mutate()}
+            disabled={!config.dataset_uid || start.isPending}
+            startIcon={<PlayArrowRoundedIcon />}
+          >
+            {start.isPending ? 'Starting…' : 'Start'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  )
+}

--- a/ui/src/pipeline/HyperparameterField.tsx
+++ b/ui/src/pipeline/HyperparameterField.tsx
@@ -1,0 +1,307 @@
+import { useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import IconButton from '@mui/material/IconButton'
+import InputAdornment from '@mui/material/InputAdornment'
+import MenuItem from '@mui/material/MenuItem'
+import Slider from '@mui/material/Slider'
+import Stack from '@mui/material/Stack'
+import Switch from '@mui/material/Switch'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+import RestartAltRoundedIcon from '@mui/icons-material/RestartAltRounded'
+import TuneRoundedIcon from '@mui/icons-material/TuneRounded'
+
+import type { ParameterSchema } from '../api/types'
+import { describeScope, formatParamValue } from './paramDisplay'
+
+interface Props {
+  schema: ParameterSchema
+  value: unknown
+  isSet: boolean
+  onChange: (value: unknown) => void
+  onReset: () => void
+  disabled?: boolean
+}
+
+/** Map a value onto a 0–100 slider position, honouring logarithmic scopes. */
+const toSliderPosition = (value: number, min: number, max: number, log: boolean): number => {
+  if (log && min > 0 && max > 0) {
+    const ratio = (Math.log(value) - Math.log(min)) / (Math.log(max) - Math.log(min))
+    return Math.min(100, Math.max(0, ratio * 100))
+  }
+  return Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100))
+}
+
+const fromSliderPosition = (position: number, min: number, max: number, log: boolean): number => {
+  if (log && min > 0 && max > 0) {
+    return Math.exp(Math.log(min) + (position / 100) * (Math.log(max) - Math.log(min)))
+  }
+  return min + (position / 100) * (max - min)
+}
+
+const roundForType = (value: number, integer: boolean): number =>
+  integer ? Math.round(value) : Number(value.toPrecision(6))
+
+/**
+ * One hyperparameter, rendered according to the schema FEDOT publishes for it.
+ *
+ * The widget is chosen from `type`: a bounded slider for continuous and discrete
+ * parameters, a dropdown for categorical ones, a switch for booleans. The
+ * sampling scope shown next to the control is the same range the FEDOT tuner
+ * would search, so a value typed here can be compared against what evolution
+ * would consider.
+ */
+export default function HyperparameterField({
+  schema,
+  value,
+  isSet,
+  onChange,
+  onReset,
+  disabled,
+}: Props) {
+  const theme = useTheme()
+  const scope = describeScope(schema)
+  const bounded = schema.minimum !== null && schema.maximum !== null
+  const isInteger = schema.value_type === 'integer' || schema.type === 'discrete'
+
+  // A local copy keeps typing responsive while the slider stays in sync.
+  const [draft, setDraft] = useState<string>(value === null || value === undefined ? '' : String(value))
+  useEffect(() => {
+    setDraft(value === null || value === undefined ? '' : String(value))
+  }, [value])
+
+  const commitNumber = (raw: string) => {
+    setDraft(raw)
+    if (raw.trim() === '') return
+    const parsed = Number(raw)
+    if (Number.isNaN(parsed)) return
+    onChange(isInteger ? Math.round(parsed) : parsed)
+  }
+
+  const label = (
+    <Stack direction="row" alignItems="center" spacing={0.6} sx={{ minWidth: 0 }}>
+      <Typography
+        sx={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.79rem',
+          fontWeight: isSet ? 700 : 500,
+          color: isSet ? 'primary.main' : 'text.primary',
+        }}
+      >
+        {schema.name}
+      </Typography>
+
+      {schema.tunable && (
+        <Tooltip
+          title={`Explored by the FEDOT tuner${schema.distribution ? ` (${schema.distribution})` : ''}`}
+        >
+          <TuneRoundedIcon sx={{ fontSize: 13, color: 'text.disabled' }} />
+        </Tooltip>
+      )}
+
+      <Box sx={{ flexGrow: 1 }} />
+
+      {scope && (
+        <Typography sx={{ fontSize: '0.68rem', color: 'text.disabled', whiteSpace: 'nowrap' }}>
+          {scope}
+        </Typography>
+      )}
+
+      {isSet && schema.default !== null && schema.default !== undefined && (
+        <Tooltip title={`Reset to the FEDOT default (${formatParamValue(schema.default)})`}>
+          <IconButton size="small" onClick={onReset} disabled={disabled} sx={{ p: 0.2 }}>
+            <RestartAltRoundedIcon sx={{ fontSize: 15 }} />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Stack>
+  )
+
+  let control: React.ReactNode
+
+  if (schema.type === 'nested' && schema.nested_variants?.length) {
+    const current = (value ?? {}) as Record<string, unknown>
+    const activeVariant =
+      schema.nested_variants.find((variant) =>
+        Object.entries(variant.fixed).every(([key, fixed]) => current[key] === fixed),
+      ) ?? schema.nested_variants[0]
+
+    control = (
+      <Stack spacing={0.8}>
+        <TextField
+          select
+          size="small"
+          value={activeVariant.label}
+          disabled={disabled}
+          onChange={(event) => {
+            const variant = schema.nested_variants!.find((item) => item.label === event.target.value)
+            if (!variant) return
+            const next: Record<string, unknown> = { ...variant.fixed }
+            for (const [key, options] of Object.entries(variant.options)) {
+              next[key] = options[0]
+            }
+            onChange(next)
+          }}
+        >
+          {schema.nested_variants.map((variant) => (
+            <MenuItem key={variant.label} value={variant.label}>
+              {variant.label}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        {Object.entries(activeVariant.options).map(([key, options]) => (
+          <TextField
+            key={key}
+            select
+            size="small"
+            label={key}
+            value={String(current[key] ?? options[0])}
+            disabled={disabled}
+            onChange={(event) => onChange({ ...current, [key]: event.target.value })}
+          >
+            {options.map((option) => (
+              <MenuItem key={String(option)} value={String(option)}>
+                {String(option)}
+              </MenuItem>
+            ))}
+          </TextField>
+        ))}
+      </Stack>
+    )
+  } else if (schema.value_type === 'boolean' && (!schema.choices || schema.choices.length <= 2)) {
+    control = (
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Switch
+          size="small"
+          checked={value === true}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.checked)}
+        />
+        <Typography sx={{ fontSize: '0.78rem', color: 'text.secondary' }}>
+          {value === true ? 'true' : 'false'}
+        </Typography>
+      </Stack>
+    )
+  } else if (schema.choices && schema.choices.length > 0) {
+    const asString = value === null || value === undefined ? '' : String(value)
+    control = (
+      <TextField
+        select
+        size="small"
+        fullWidth
+        value={schema.choices.some((choice) => String(choice) === asString) ? asString : ''}
+        disabled={disabled}
+        onChange={(event) => {
+          const chosen = schema.choices!.find((choice) => String(choice) === event.target.value)
+          onChange(chosen ?? event.target.value)
+        }}
+      >
+        {schema.choices.map((choice) => (
+          <MenuItem key={String(choice)} value={String(choice)}>
+            {String(choice)}
+          </MenuItem>
+        ))}
+      </TextField>
+    )
+  } else if (bounded && (schema.type === 'continuous' || schema.type === 'discrete')) {
+    const min = schema.minimum!
+    const max = schema.maximum!
+    // An empty field means "not set", which is not the same as zero — without
+    // this check every parameter that has no default reads as out of scope.
+    const hasValue = typeof value === 'number' || draft.trim() !== ''
+    const numeric = typeof value === 'number' ? value : Number(draft)
+    const valid = hasValue && Number.isFinite(numeric)
+    const outOfScope = valid && (numeric < min || numeric > max)
+
+    control = (
+      <Stack direction="row" spacing={1.5} alignItems="center">
+        <Slider
+          size="small"
+          disabled={disabled}
+          value={valid ? toSliderPosition(numeric, min, max, schema.log_scale) : 0}
+          min={0}
+          max={100}
+          step={0.1}
+          onChange={(_, position) =>
+            onChange(
+              roundForType(
+                fromSliderPosition(position as number, min, max, schema.log_scale),
+                isInteger,
+              ),
+            )
+          }
+          sx={{ flexGrow: 1 }}
+        />
+        <TextField
+          size="small"
+          value={draft}
+          disabled={disabled}
+          onChange={(event) => commitNumber(event.target.value)}
+          error={outOfScope}
+          helperText={outOfScope ? 'outside the tuner scope' : undefined}
+          sx={{ width: 118 }}
+          slotProps={{
+            input: {
+              endAdornment: schema.log_scale ? (
+                <InputAdornment position="end">
+                  <Tooltip title="This parameter is searched on a logarithmic scale">
+                    <Typography sx={{ fontSize: '0.6rem', color: 'text.disabled' }}>log</Typography>
+                  </Tooltip>
+                </InputAdornment>
+              ) : undefined,
+            },
+          }}
+        />
+      </Stack>
+    )
+  } else {
+    control = (
+      <TextField
+        size="small"
+        fullWidth
+        value={draft}
+        disabled={disabled}
+        onChange={(event) => {
+          setDraft(event.target.value)
+          if (schema.value_type === 'number' || schema.value_type === 'integer') {
+            commitNumber(event.target.value)
+          } else {
+            onChange(event.target.value)
+          }
+        }}
+      />
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        px: 1.25,
+        py: 0.9,
+        borderRadius: 1.5,
+        border: '1px solid',
+        borderColor: isSet ? alpha(theme.palette.primary.main, 0.35) : 'transparent',
+        bgcolor: isSet ? alpha(theme.palette.primary.main, 0.05) : 'transparent',
+        '&:hover': { bgcolor: alpha(theme.palette.action.hover, 0.5) },
+      }}
+    >
+      {label}
+      <Box sx={{ mt: 0.6 }}>{control}</Box>
+      {schema.default !== null && schema.default !== undefined && (
+        <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }} alignItems="center">
+          <Typography sx={{ fontSize: '0.66rem', color: 'text.disabled' }}>default</Typography>
+          <Chip
+            size="small"
+            variant="outlined"
+            label={formatParamValue(schema.default)}
+            sx={{ height: 16, fontSize: '0.62rem', '& .MuiChip-label': { px: 0.6 } }}
+          />
+        </Stack>
+      )}
+    </Box>
+  )
+}

--- a/ui/src/pipeline/NodeInspector.tsx
+++ b/ui/src/pipeline/NodeInspector.tsx
@@ -1,0 +1,218 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import Divider from '@mui/material/Divider'
+import InputAdornment from '@mui/material/InputAdornment'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import DeleteOutlineRoundedIcon from '@mui/icons-material/DeleteOutlineRounded'
+import SearchRoundedIcon from '@mui/icons-material/SearchRounded'
+
+import { api } from '../api/client'
+import type { GraphNode } from '../api/types'
+import { groupColor } from '../theme'
+import HyperparameterField from './HyperparameterField'
+import { effectiveValue, isChanged } from './paramDisplay'
+
+interface Props {
+  node: GraphNode
+  onParamsChange: (params: Record<string, unknown>) => void
+  onDelete: () => void
+  readOnly?: boolean
+}
+
+/**
+ * Side panel for the selected node: what the operation is, and a typed editor
+ * for every hyperparameter FEDOT knows it accepts.
+ *
+ * Parameters the tuner explores are listed first — those are the ones that
+ * distinguish a hand-built pipeline from a composed one.
+ */
+export default function NodeInspector({ node, onParamsChange, onDelete, readOnly }: Props) {
+  const [filter, setFilter] = useState('')
+
+  const { data: operation, isLoading, error } = useQuery({
+    queryKey: ['operation', node.operation],
+    queryFn: () => api.operation(node.operation),
+    staleTime: Infinity,
+  })
+
+  const accent = groupColor(node.group ?? undefined)
+
+  const parameters = useMemo(() => {
+    if (!operation) return []
+    const needle = filter.trim().toLowerCase()
+    const matching = needle
+      ? operation.parameters.filter((schema) => schema.name.toLowerCase().includes(needle))
+      : operation.parameters
+    // Tuned parameters first, then the rest alphabetically.
+    return [...matching].sort((a, b) => {
+      if (a.tunable !== b.tunable) return a.tunable ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+  }, [operation, filter])
+
+  const changedCount = useMemo(
+    () =>
+      Object.entries(node.params ?? {}).filter(([name, value]) =>
+        isChanged(name, value, node.defaults ?? {}),
+      ).length,
+    [node.params, node.defaults],
+  )
+
+  const setParam = (name: string, value: unknown) => {
+    onParamsChange({ ...node.params, [name]: value })
+  }
+
+  const resetParam = (name: string) => {
+    const next = { ...node.params }
+    const fallback = operation?.defaults?.[name]
+    if (fallback === undefined) {
+      delete next[name]
+    } else {
+      next[name] = fallback
+    }
+    onParamsChange(next)
+  }
+
+  const resetAll = () => onParamsChange({ ...(operation?.defaults ?? {}) })
+
+  return (
+    <Stack sx={{ height: '100%', minHeight: 0 }}>
+      <Box sx={{ p: 1.75, borderBottom: '1px solid', borderColor: 'divider' }}>
+        <Stack direction="row" alignItems="flex-start" spacing={1}>
+          <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+            <Typography
+              variant="h3"
+              sx={{ fontFamily: '"JetBrains Mono", monospace', color: accent }}
+              noWrap
+            >
+              {node.operation}
+            </Typography>
+            {operation?.description && (
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.4, fontSize: '0.8rem' }}>
+                {operation.description}
+              </Typography>
+            )}
+          </Box>
+          {!readOnly && (
+            <Tooltip title="Remove this node">
+              <Button
+                size="small"
+                color="error"
+                onClick={onDelete}
+                startIcon={<DeleteOutlineRoundedIcon fontSize="small" />}
+              >
+                Remove
+              </Button>
+            </Tooltip>
+          )}
+        </Stack>
+
+        <Stack direction="row" spacing={0.5} sx={{ mt: 1, flexWrap: 'wrap', gap: 0.5 }}>
+          <Chip size="small" label={node.kind ?? 'model'} variant="outlined" />
+          {operation?.tasks.map((task) => (
+            <Chip key={task} size="small" label={task} variant="outlined" />
+          ))}
+          {(node.tags ?? []).slice(0, 5).map((tag) => (
+            <Chip key={tag} size="small" label={tag} sx={{ height: 20, fontSize: '0.68rem' }} />
+          ))}
+        </Stack>
+
+        {operation && (
+          <Typography sx={{ mt: 0.9, fontSize: '0.72rem', color: 'text.disabled' }}>
+            input {operation.input_types.join(', ') || '—'} → output{' '}
+            {operation.output_types.join(', ') || '—'}
+          </Typography>
+        )}
+      </Box>
+
+      <Box sx={{ px: 1.75, py: 1.25 }}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Typography variant="subtitle2">Hyperparameters</Typography>
+          {changedCount > 0 && (
+            <Chip
+              size="small"
+              color="primary"
+              label={`${changedCount} changed`}
+              sx={{ height: 19, fontSize: '0.68rem' }}
+            />
+          )}
+          <Box sx={{ flexGrow: 1 }} />
+          {!readOnly && operation && (
+            <Button size="small" onClick={resetAll}>
+              Reset all
+            </Button>
+          )}
+        </Stack>
+
+        {operation && operation.parameters.length > 6 && (
+          <TextField
+            size="small"
+            fullWidth
+            placeholder="Filter parameters"
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            sx={{ mt: 1 }}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchRoundedIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+        )}
+      </Box>
+
+      <Divider />
+
+      <Box sx={{ flexGrow: 1, minHeight: 0, overflowY: 'auto', px: 1, py: 1 }}>
+        {isLoading && (
+          <Stack alignItems="center" sx={{ py: 4 }}>
+            <CircularProgress size={22} />
+          </Stack>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ m: 1 }}>
+            Could not load the parameter schema for <code>{node.operation}</code>.
+          </Alert>
+        )}
+
+        {operation && parameters.length === 0 && (
+          <Typography sx={{ p: 2, color: 'text.disabled', fontSize: '0.85rem' }}>
+            {filter
+              ? 'No parameter matches that filter.'
+              : 'This operation takes no configurable hyperparameters.'}
+          </Typography>
+        )}
+
+        <Stack spacing={0.4}>
+          {parameters.map((schema) => (
+            <HyperparameterField
+              key={schema.name}
+              schema={schema}
+              value={effectiveValue(schema, node.params ?? {})}
+              isSet={
+                schema.name in (node.params ?? {}) &&
+                isChanged(schema.name, node.params[schema.name], node.defaults ?? {})
+              }
+              onChange={(value) => setParam(schema.name, value)}
+              onReset={() => resetParam(schema.name)}
+              disabled={readOnly}
+            />
+          ))}
+        </Stack>
+      </Box>
+    </Stack>
+  )
+}

--- a/ui/src/pipeline/OperationPalette.tsx
+++ b/ui/src/pipeline/OperationPalette.tsx
@@ -1,0 +1,202 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import Collapse from '@mui/material/Collapse'
+import InputAdornment from '@mui/material/InputAdornment'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+import ExpandLessRoundedIcon from '@mui/icons-material/ExpandLessRounded'
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
+import SearchRoundedIcon from '@mui/icons-material/SearchRounded'
+
+import { api } from '../api/client'
+import type { OperationSummary } from '../api/types'
+import { groupColor } from '../theme'
+
+interface Props {
+  task: string | null
+  onAdd: (operation: OperationSummary) => void
+}
+
+const GROUP_ORDER = [
+  'source',
+  'preprocessing',
+  'feature_engineering',
+  'ts_transform',
+  'linear',
+  'non_linear',
+  'tree',
+  'ensemble',
+  'ts_model',
+  'deep',
+  'model',
+  'data_operation',
+]
+
+/** The operation palette, filtered to what the selected task supports. */
+export default function OperationPalette({ task, onAdd }: Props) {
+  const theme = useTheme()
+  const [search, setSearch] = useState('')
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+
+  const { data: operations = [], isLoading } = useQuery({
+    queryKey: ['operations', task],
+    queryFn: () => api.operations(task ? { task } : {}),
+    staleTime: Infinity,
+  })
+
+  const grouped = useMemo(() => {
+    const needle = search.trim().toLowerCase()
+    const matching = needle
+      ? operations.filter(
+          (operation) =>
+            operation.id.toLowerCase().includes(needle) ||
+            operation.tags.some((tag) => tag.toLowerCase().includes(needle)) ||
+            (operation.description ?? '').toLowerCase().includes(needle),
+        )
+      : operations
+
+    const buckets = new Map<string, OperationSummary[]>()
+    for (const operation of matching) {
+      const list = buckets.get(operation.group) ?? []
+      list.push(operation)
+      buckets.set(operation.group, list)
+    }
+    return [...buckets.entries()].sort(
+      (a, b) => GROUP_ORDER.indexOf(a[0]) - GROUP_ORDER.indexOf(b[0]),
+    )
+  }, [operations, search])
+
+  return (
+    <Stack sx={{ height: '100%', minHeight: 0 }}>
+      <Box sx={{ p: 1.5, pb: 1 }}>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Operations
+          {task && (
+            <Typography component="span" sx={{ ml: 0.75, fontSize: '0.72rem', color: 'text.disabled' }}>
+              for {task.replace(/_/g, ' ')}
+            </Typography>
+          )}
+        </Typography>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="Search by name or tag"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchRoundedIcon fontSize="small" />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+      </Box>
+
+      <Box sx={{ flexGrow: 1, minHeight: 0, overflowY: 'auto', px: 1, pb: 1.5 }}>
+        {isLoading && (
+          <Stack alignItems="center" sx={{ py: 4 }}>
+            <CircularProgress size={22} />
+          </Stack>
+        )}
+
+        {!isLoading && grouped.length === 0 && (
+          <Typography sx={{ p: 2, fontSize: '0.83rem', color: 'text.disabled' }}>
+            No operation matches that search.
+          </Typography>
+        )}
+
+        {grouped.map(([group, items]) => {
+          const accent = groupColor(group)
+          const isCollapsed = collapsed[group] ?? false
+          return (
+            <Box key={group} sx={{ mb: 0.75 }}>
+              <Stack
+                direction="row"
+                alignItems="center"
+                spacing={0.75}
+                onClick={() => setCollapsed((state) => ({ ...state, [group]: !isCollapsed }))}
+                sx={{ px: 0.75, py: 0.5, cursor: 'pointer', borderRadius: 1 }}
+              >
+                <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: accent }} />
+                <Typography sx={{ fontSize: '0.74rem', fontWeight: 700, color: 'text.secondary' }}>
+                  {group.replace(/_/g, ' ')}
+                </Typography>
+                <Typography sx={{ fontSize: '0.7rem', color: 'text.disabled' }}>
+                  {items.length}
+                </Typography>
+                <Box sx={{ flexGrow: 1 }} />
+                {isCollapsed ? (
+                  <ExpandMoreRoundedIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
+                ) : (
+                  <ExpandLessRoundedIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
+                )}
+              </Stack>
+
+              <Collapse in={!isCollapsed}>
+                <Stack sx={{ gap: 0.25 }}>
+                  {items.map((operation) => (
+                    <Tooltip
+                      key={operation.id}
+                      title={operation.description ?? operation.id}
+                      placement="right"
+                    >
+                      <Stack
+                        direction="row"
+                        alignItems="center"
+                        spacing={0.75}
+                        onClick={() => onAdd(operation)}
+                        sx={{
+                          px: 1,
+                          py: 0.55,
+                          borderRadius: 1.25,
+                          cursor: 'pointer',
+                          borderLeft: '2px solid',
+                          borderColor: alpha(accent, 0.5),
+                          '&:hover': { bgcolor: alpha(accent, 0.12) },
+                        }}
+                      >
+                        <Typography
+                          sx={{
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: '0.76rem',
+                            flexGrow: 1,
+                          }}
+                          noWrap
+                        >
+                          {operation.id}
+                        </Typography>
+                        {!operation.is_default && (
+                          <Chip
+                            size="small"
+                            label="non-default"
+                            sx={{
+                              height: 15,
+                              fontSize: '0.58rem',
+                              '& .MuiChip-label': { px: 0.5 },
+                              color: theme.palette.warning.main,
+                              borderColor: alpha(theme.palette.warning.main, 0.4),
+                            }}
+                            variant="outlined"
+                          />
+                        )}
+                      </Stack>
+                    </Tooltip>
+                  ))}
+                </Stack>
+              </Collapse>
+            </Box>
+          )
+        })}
+      </Box>
+    </Stack>
+  )
+}

--- a/ui/src/pipeline/PipelineCanvas.tsx
+++ b/ui/src/pipeline/PipelineCanvas.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+  type Connection,
+  type Edge,
+  type NodeMouseHandler,
+} from '@xyflow/react'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+
+import type { PipelineGraph } from '../api/types'
+import { groupColor } from '../theme'
+import PipelineNodeCard, { type PipelineFlowNode } from './PipelineNodeCard'
+import { layoutGraph, type LayoutDirection } from './layout'
+import { selectVisibleParams } from './paramDisplay'
+
+const nodeTypes = { pipelineNode: PipelineNodeCard }
+
+interface Props {
+  graph: PipelineGraph
+  direction?: LayoutDirection
+  selectedNodeId?: string | null
+  problems?: Record<string, string>
+  readOnly?: boolean
+  onSelect?: (nodeId: string | null) => void
+  onConnect?: (source: string, target: string) => void
+  onDisconnect?: (source: string, target: string) => void
+  emptyHint?: string
+}
+
+function Canvas({
+  graph,
+  direction = 'LR',
+  selectedNodeId,
+  problems,
+  readOnly,
+  onSelect,
+  onConnect,
+  onDisconnect,
+  emptyHint,
+}: Props) {
+  const theme = useTheme()
+  const { fitView } = useReactFlow()
+
+  const flowNodes = useMemo<PipelineFlowNode[]>(() => {
+    const nodes = graph.nodes.map((node) => {
+      const { visible, hidden, total } = selectVisibleParams(node)
+      return {
+        id: node.id,
+        type: 'pipelineNode' as const,
+        position: { x: 0, y: 0 },
+        selected: node.id === selectedNodeId,
+        data: {
+          operation: node.operation,
+          group: node.group ?? 'model',
+          kind: node.kind ?? 'model',
+          description: node.description,
+          tags: node.tags ?? [],
+          params: node.params ?? {},
+          defaults: node.defaults ?? {},
+          isPrimary: node.is_primary,
+          isRoot: node.is_root,
+          visibleParams: visible,
+          paramCount: total,
+          hiddenParamCount: hidden,
+          problem: problems?.[node.id] ?? null,
+          readOnly,
+          horizontal: direction === 'LR',
+        },
+      }
+    })
+    return layoutGraph(nodes, graph.edges.map((edge) => ({
+      id: edge.id ?? `${edge.source}->${edge.target}`,
+      source: edge.source,
+      target: edge.target,
+    })), direction)
+  }, [graph, direction, selectedNodeId, problems, readOnly])
+
+  const flowEdges = useMemo<Edge[]>(
+    () =>
+      graph.edges.map((edge) => {
+        const sourceNode = graph.nodes.find((node) => node.id === edge.source)
+        const stroke = groupColor(sourceNode?.group ?? undefined)
+        return {
+          id: edge.id ?? `${edge.source}->${edge.target}`,
+          source: edge.source,
+          target: edge.target,
+          animated: false,
+          style: { stroke: alpha(stroke, 0.75), strokeWidth: 1.8 },
+          markerEnd: { type: 'arrowclosed', color: alpha(stroke, 0.75), width: 16, height: 16 } as never,
+        }
+      }),
+    [graph],
+  )
+
+  // Re-fit whenever the topology changes, so a newly composed pipeline is
+  // fully visible without the user reaching for the zoom controls.
+  const topologyKey = useMemo(
+    () => `${graph.nodes.map((n) => n.id).join(',')}|${graph.edges.length}|${direction}`,
+    [graph, direction],
+  )
+  useEffect(() => {
+    const timer = window.setTimeout(() => fitView({ padding: 0.18, duration: 220 }), 40)
+    return () => window.clearTimeout(timer)
+  }, [topologyKey, fitView])
+
+  const handleNodeClick = useCallback<NodeMouseHandler>(
+    (_, node) => onSelect?.(node.id),
+    [onSelect],
+  )
+
+  const handleConnect = useCallback(
+    (connection: Connection) => {
+      if (connection.source && connection.target) {
+        onConnect?.(connection.source, connection.target)
+      }
+    },
+    [onConnect],
+  )
+
+  const handleEdgesDelete = useCallback(
+    (edges: Edge[]) => {
+      for (const edge of edges) onDisconnect?.(edge.source, edge.target)
+    },
+    [onDisconnect],
+  )
+
+  if (graph.nodes.length === 0) {
+    return (
+      <Box
+        sx={{
+          height: '100%',
+          display: 'grid',
+          placeItems: 'center',
+          color: 'text.disabled',
+          px: 4,
+          textAlign: 'center',
+        }}
+      >
+        <Typography variant="body2">{emptyHint ?? 'This pipeline has no nodes yet.'}</Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <ReactFlow
+      nodes={flowNodes}
+      edges={flowEdges}
+      nodeTypes={nodeTypes}
+      onNodeClick={handleNodeClick}
+      onPaneClick={() => onSelect?.(null)}
+      onConnect={handleConnect}
+      onEdgesDelete={handleEdgesDelete}
+      nodesDraggable={false}
+      nodesConnectable={!readOnly}
+      elementsSelectable
+      edgesFocusable={!readOnly}
+      deleteKeyCode={readOnly ? null : ['Backspace', 'Delete']}
+      minZoom={0.15}
+      maxZoom={2.5}
+      proOptions={{ hideAttribution: true }}
+      style={{ background: theme.palette.background.default }}
+    >
+      <Background
+        variant={BackgroundVariant.Dots}
+        gap={18}
+        size={1}
+        color={theme.palette.divider}
+      />
+      <Controls showInteractive={false} />
+      <MiniMap
+        pannable
+        zoomable
+        nodeColor={(node) => groupColor((node.data as { group?: string })?.group)}
+        maskColor={alpha(theme.palette.background.default, 0.72)}
+        style={{
+          background: theme.palette.background.paper,
+          border: `1px solid ${theme.palette.divider}`,
+        }}
+      />
+    </ReactFlow>
+  )
+}
+
+/** Zoom, pan and a minimap — all of which the previous editor left disabled. */
+export default function PipelineCanvas(props: Props) {
+  const [ready, setReady] = useState(false)
+  useEffect(() => setReady(true), [])
+  if (!ready) return null
+
+  return (
+    <ReactFlowProvider>
+      <Canvas {...props} />
+    </ReactFlowProvider>
+  )
+}

--- a/ui/src/pipeline/PipelineCanvas.tsx
+++ b/ui/src/pipeline/PipelineCanvas.tsx
@@ -51,7 +51,7 @@ function Canvas({
 
   const flowNodes = useMemo<PipelineFlowNode[]>(() => {
     const nodes = graph.nodes.map((node) => {
-      const { visible, hidden, total } = selectVisibleParams(node)
+      const { visible, hidden, total, fromDefaults } = selectVisibleParams(node)
       return {
         id: node.id,
         type: 'pipelineNode' as const,
@@ -68,7 +68,9 @@ function Canvas({
           isPrimary: node.is_primary,
           isRoot: node.is_root,
           visibleParams: visible,
-          paramCount: total,
+          paramsFromDefaults: fromDefaults,
+          // The caption row above default values needs its own line of height.
+          paramCount: total + (fromDefaults ? 1 : 0),
           hiddenParamCount: hidden,
           problem: problems?.[node.id] ?? null,
           readOnly,

--- a/ui/src/pipeline/PipelineNodeCard.tsx
+++ b/ui/src/pipeline/PipelineNodeCard.tsx
@@ -1,0 +1,187 @@
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react'
+import { alpha, useTheme } from '@mui/material/styles'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import FlagRoundedIcon from '@mui/icons-material/FlagRounded'
+import InputRoundedIcon from '@mui/icons-material/InputRounded'
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded'
+
+import { groupColor } from '../theme'
+import { formatParamValue } from './paramDisplay'
+
+export interface PipelineNodeData extends Record<string, unknown> {
+  operation: string
+  group: string
+  kind: string
+  description?: string | null
+  tags: string[]
+  /** Parameters explicitly set on this node. */
+  params: Record<string, unknown>
+  /** Defaults FEDOT would apply, used to mark what the user changed. */
+  defaults: Record<string, unknown>
+  isPrimary: boolean
+  isRoot: boolean
+  /** Rows displayed on the card; precomputed so layout can size the node. */
+  visibleParams: { name: string; value: unknown; changed: boolean }[]
+  paramCount: number
+  hiddenParamCount: number
+  problem?: string | null
+  readOnly?: boolean
+  /** Must match the layout direction so the handles line up with the edges. */
+  horizontal: boolean
+}
+
+export type PipelineFlowNode = Node<PipelineNodeData, 'pipelineNode'>
+
+/**
+ * A pipeline node drawn as a card.
+ *
+ * The old editor rendered a circle with the text `name id:0` and kept
+ * hyperparameters entirely out of sight. Here the operation, its category and
+ * the parameters that actually differ from FEDOT's defaults are all legible at
+ * a glance, which is what makes a composed pipeline reviewable without clicking
+ * through every node.
+ */
+export default function PipelineNodeCard({ data, selected }: NodeProps<PipelineFlowNode>) {
+  const theme = useTheme()
+  const accent = groupColor(data.group)
+  const hasProblem = Boolean(data.problem)
+
+  return (
+    <Box
+      sx={{
+        // The size is declared on the flow node so React Flow can route edges
+        // without measuring; the card simply fills it.
+        width: '100%',
+        height: '100%',
+        borderRadius: 2,
+        overflow: 'hidden',
+        bgcolor: 'background.paper',
+        border: '1px solid',
+        borderColor: hasProblem
+          ? theme.palette.error.main
+          : selected
+            ? accent
+            : theme.palette.divider,
+        boxShadow: selected
+          ? `0 0 0 2px ${alpha(accent, 0.45)}, 0 8px 24px ${alpha('#000', 0.18)}`
+          : `0 1px 3px ${alpha('#000', 0.16)}`,
+        transition: 'box-shadow 120ms ease, border-color 120ms ease',
+      }}
+    >
+      <Handle
+        type="target"
+        position={data.horizontal ? Position.Left : Position.Top}
+        style={{
+          width: 9,
+          height: 9,
+          background: accent,
+          border: 'none',
+          // Primary nodes take no input, so the dot is hidden — but the handle
+          // itself stays mounted so its geometry matches what layout declared.
+          opacity: data.isPrimary ? 0 : 1,
+        }}
+        isConnectable={!data.readOnly}
+      />
+
+      <Box sx={{ height: 3, bgcolor: accent }} />
+
+      <Box sx={{ px: 1.25, pt: 0.85, pb: 1 }}>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Tooltip title={data.description ?? data.operation} placement="top">
+            <Typography
+              variant="subtitle2"
+              noWrap
+              sx={{ flexGrow: 1, fontFamily: '"JetBrains Mono", monospace', fontSize: '0.86rem' }}
+            >
+              {data.operation}
+            </Typography>
+          </Tooltip>
+
+          {data.isPrimary && (
+            <Tooltip title="Primary node — receives the input data">
+              <InputRoundedIcon sx={{ fontSize: 15, color: 'text.disabled' }} />
+            </Tooltip>
+          )}
+          {data.isRoot && (
+            <Tooltip title="Root node — produces the prediction">
+              <FlagRoundedIcon sx={{ fontSize: 15, color: accent }} />
+            </Tooltip>
+          )}
+          {hasProblem && (
+            <Tooltip title={data.problem ?? ''}>
+              <WarningAmberRoundedIcon sx={{ fontSize: 16, color: 'error.main' }} />
+            </Tooltip>
+          )}
+        </Stack>
+
+        <Chip
+          label={data.group.replace(/_/g, ' ')}
+          size="small"
+          sx={{
+            mt: 0.4,
+            height: 17,
+            fontSize: '0.62rem',
+            bgcolor: alpha(accent, 0.14),
+            color: accent,
+            '& .MuiChip-label': { px: 0.7 },
+          }}
+        />
+
+        {data.visibleParams.length > 0 && (
+          <Stack sx={{ mt: 0.7, gap: 0.15 }}>
+            {data.visibleParams.map((param) => (
+              <Stack key={param.name} direction="row" spacing={0.5} sx={{ minWidth: 0 }}>
+                <Typography
+                  noWrap
+                  sx={{
+                    fontSize: '0.68rem',
+                    color: 'text.secondary',
+                    fontFamily: '"JetBrains Mono", monospace',
+                    maxWidth: 96,
+                  }}
+                >
+                  {param.name}
+                </Typography>
+                <Typography
+                  noWrap
+                  sx={{
+                    fontSize: '0.68rem',
+                    flexGrow: 1,
+                    textAlign: 'right',
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontWeight: param.changed ? 700 : 400,
+                    color: param.changed ? accent : 'text.primary',
+                  }}
+                >
+                  {formatParamValue(param.value)}
+                </Typography>
+              </Stack>
+            ))}
+            {data.hiddenParamCount > 0 && (
+              <Typography sx={{ fontSize: '0.64rem', color: 'text.disabled' }}>
+                +{data.hiddenParamCount} more
+              </Typography>
+            )}
+          </Stack>
+        )}
+
+        {data.visibleParams.length === 0 && (
+          <Typography sx={{ mt: 0.6, fontSize: '0.68rem', color: 'text.disabled' }}>
+            default hyperparameters
+          </Typography>
+        )}
+      </Box>
+
+      <Handle
+        type="source"
+        position={data.horizontal ? Position.Right : Position.Bottom}
+        style={{ width: 9, height: 9, background: accent, border: 'none' }}
+        isConnectable={!data.readOnly}
+      />
+    </Box>
+  )
+}

--- a/ui/src/pipeline/PipelineNodeCard.tsx
+++ b/ui/src/pipeline/PipelineNodeCard.tsx
@@ -26,6 +26,8 @@ export interface PipelineNodeData extends Record<string, unknown> {
   isRoot: boolean
   /** Rows displayed on the card; precomputed so layout can size the node. */
   visibleParams: { name: string; value: unknown; changed: boolean }[]
+  /** The rows are FEDOT's defaults because nothing is set on the node itself. */
+  paramsFromDefaults: boolean
   paramCount: number
   hiddenParamCount: number
   problem?: string | null
@@ -133,6 +135,19 @@ export default function PipelineNodeCard({ data, selected }: NodeProps<PipelineF
 
         {data.visibleParams.length > 0 && (
           <Stack sx={{ mt: 0.7, gap: 0.15 }}>
+            {data.paramsFromDefaults && (
+              <Tooltip
+                title={`FEDOT applies these when the node is created (default_operation_params.json): ${data.visibleParams
+                  .map((param) => `${param.name} = ${formatParamValue(param.value)}`)
+                  .join(', ')}`}
+              >
+                <Typography
+                  sx={{ fontSize: '0.6rem', color: 'text.disabled', fontStyle: 'italic' }}
+                >
+                  FEDOT defaults
+                </Typography>
+              </Tooltip>
+            )}
             {data.visibleParams.map((param) => (
               <Stack key={param.name} direction="row" spacing={0.5} sx={{ minWidth: 0 }}>
                 <Typography
@@ -154,7 +169,11 @@ export default function PipelineNodeCard({ data, selected }: NodeProps<PipelineF
                     textAlign: 'right',
                     fontFamily: '"JetBrains Mono", monospace',
                     fontWeight: param.changed ? 700 : 400,
-                    color: param.changed ? accent : 'text.primary',
+                    color: param.changed
+                      ? accent
+                      : data.paramsFromDefaults
+                        ? 'text.secondary'
+                        : 'text.primary',
                   }}
                 >
                   {formatParamValue(param.value)}
@@ -171,7 +190,7 @@ export default function PipelineNodeCard({ data, selected }: NodeProps<PipelineF
 
         {data.visibleParams.length === 0 && (
           <Typography sx={{ mt: 0.6, fontSize: '0.68rem', color: 'text.disabled' }}>
-            default hyperparameters
+            no hyperparameters
           </Typography>
         )}
       </Box>

--- a/ui/src/pipeline/editorStore.ts
+++ b/ui/src/pipeline/editorStore.ts
@@ -1,0 +1,230 @@
+import { create } from 'zustand'
+
+import type { GraphEdge, GraphNode, OperationSummary, PipelineGraph, ValidationResult } from '../api/types'
+
+const emptyGraph = (): PipelineGraph => ({ uid: '', nodes: [], edges: [], depth: 0, length: 0 })
+
+let nodeCounter = 0
+const nextNodeId = (existing: GraphNode[]): string => {
+  // Keep ids unique even after nodes are deleted and the counter is reused.
+  const taken = new Set(existing.map((node) => node.id))
+  let candidate: string
+  do {
+    candidate = `n${nodeCounter++}`
+  } while (taken.has(candidate))
+  return candidate
+}
+
+const recomputeRelations = (graph: PipelineGraph): PipelineGraph => {
+  const parents = new Map<string, string[]>()
+  const children = new Map<string, string[]>()
+  for (const node of graph.nodes) {
+    parents.set(node.id, [])
+    children.set(node.id, [])
+  }
+  for (const edge of graph.edges) {
+    parents.get(edge.target)?.push(edge.source)
+    children.get(edge.source)?.push(edge.target)
+  }
+  return {
+    ...graph,
+    nodes: graph.nodes.map((node) => ({
+      ...node,
+      parents: parents.get(node.id) ?? [],
+      children: children.get(node.id) ?? [],
+      is_primary: (parents.get(node.id) ?? []).length === 0,
+      is_root: (children.get(node.id) ?? []).length === 0,
+    })),
+  }
+}
+
+/** Would adding `source -> target` close a cycle? */
+const wouldCycle = (edges: GraphEdge[], source: string, target: string): boolean => {
+  const adjacency = new Map<string, string[]>()
+  for (const edge of edges) {
+    const list = adjacency.get(edge.source) ?? []
+    list.push(edge.target)
+    adjacency.set(edge.source, list)
+  }
+  const stack = [target]
+  const seen = new Set<string>()
+  while (stack.length) {
+    const current = stack.pop()!
+    if (current === source) return true
+    if (seen.has(current)) continue
+    seen.add(current)
+    stack.push(...(adjacency.get(current) ?? []))
+  }
+  return false
+}
+
+interface EditorState {
+  graph: PipelineGraph
+  task: string | null
+  selectedNodeId: string | null
+  validation: ValidationResult | null
+  dirty: boolean
+  name: string
+  pipelineUid: string | null
+
+  setGraph: (graph: PipelineGraph, options?: { name?: string; uid?: string | null; clean?: boolean }) => void
+  reset: () => void
+  setTask: (task: string | null) => void
+  setName: (name: string) => void
+  setValidation: (validation: ValidationResult | null) => void
+  select: (nodeId: string | null) => void
+
+  addOperation: (operation: OperationSummary, defaults: Record<string, unknown>) => string
+  removeNode: (nodeId: string) => void
+  replaceOperation: (nodeId: string, operation: OperationSummary, defaults: Record<string, unknown>) => void
+  setNodeParams: (nodeId: string, params: Record<string, unknown>) => void
+  connect: (source: string, target: string) => string | null
+  disconnect: (source: string, target: string) => void
+}
+
+export const useEditorStore = create<EditorState>((set, get) => ({
+  graph: emptyGraph(),
+  task: null,
+  selectedNodeId: null,
+  validation: null,
+  dirty: false,
+  name: 'Untitled pipeline',
+  pipelineUid: null,
+
+  setGraph: (graph, options) =>
+    set({
+      graph: recomputeRelations(graph),
+      selectedNodeId: null,
+      validation: null,
+      dirty: options?.clean ? false : true,
+      ...(options?.name !== undefined ? { name: options.name } : {}),
+      ...(options?.uid !== undefined ? { pipelineUid: options.uid } : {}),
+    }),
+
+  reset: () =>
+    set({
+      graph: emptyGraph(),
+      selectedNodeId: null,
+      validation: null,
+      dirty: false,
+      name: 'Untitled pipeline',
+      pipelineUid: null,
+    }),
+
+  setTask: (task) => set({ task, validation: null }),
+  setName: (name) => set({ name, dirty: true }),
+  setValidation: (validation) => set({ validation }),
+  select: (nodeId) => set({ selectedNodeId: nodeId }),
+
+  addOperation: (operation, defaults) => {
+    const { graph } = get()
+    const id = nextNodeId(graph.nodes)
+    const node: GraphNode = {
+      id,
+      operation: operation.id,
+      label: operation.id,
+      kind: operation.kind,
+      group: operation.group,
+      description: operation.description,
+      tags: operation.tags,
+      params: { ...defaults },
+      defaults: { ...defaults },
+      parents: [],
+      children: [],
+      is_primary: true,
+      is_root: true,
+    }
+    set({
+      graph: recomputeRelations({ ...graph, nodes: [...graph.nodes, node] }),
+      selectedNodeId: id,
+      validation: null,
+      dirty: true,
+    })
+    return id
+  },
+
+  removeNode: (nodeId) => {
+    const { graph, selectedNodeId } = get()
+    set({
+      graph: recomputeRelations({
+        ...graph,
+        nodes: graph.nodes.filter((node) => node.id !== nodeId),
+        edges: graph.edges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId),
+      }),
+      selectedNodeId: selectedNodeId === nodeId ? null : selectedNodeId,
+      validation: null,
+      dirty: true,
+    })
+  },
+
+  replaceOperation: (nodeId, operation, defaults) => {
+    const { graph } = get()
+    set({
+      graph: recomputeRelations({
+        ...graph,
+        nodes: graph.nodes.map((node) =>
+          node.id === nodeId
+            ? {
+                ...node,
+                operation: operation.id,
+                label: operation.id,
+                kind: operation.kind,
+                group: operation.group,
+                description: operation.description,
+                tags: operation.tags,
+                // Parameters belong to the previous operation; start clean.
+                params: { ...defaults },
+                defaults: { ...defaults },
+              }
+            : node,
+        ),
+      }),
+      validation: null,
+      dirty: true,
+    })
+  },
+
+  setNodeParams: (nodeId, params) => {
+    const { graph } = get()
+    set({
+      graph: {
+        ...graph,
+        nodes: graph.nodes.map((node) => (node.id === nodeId ? { ...node, params } : node)),
+      },
+      validation: null,
+      dirty: true,
+    })
+  },
+
+  connect: (source, target) => {
+    const { graph } = get()
+    if (source === target) return 'A node cannot be its own parent'
+    if (graph.edges.some((edge) => edge.source === source && edge.target === target)) {
+      return 'These nodes are already connected'
+    }
+    if (wouldCycle(graph.edges, source, target)) {
+      return 'That connection would create a cycle — pipelines must stay acyclic'
+    }
+    set({
+      graph: recomputeRelations({
+        ...graph,
+        edges: [...graph.edges, { id: `${source}->${target}`, source, target }],
+      }),
+      validation: null,
+      dirty: true,
+    })
+    return null
+  },
+
+  disconnect: (source, target) => {
+    const { graph } = get()
+    set({
+      graph: recomputeRelations({
+        ...graph,
+        edges: graph.edges.filter((edge) => !(edge.source === source && edge.target === target)),
+      }),
+      validation: null,
+      dirty: true,
+    })
+  },
+}))

--- a/ui/src/pipeline/layout.ts
+++ b/ui/src/pipeline/layout.ts
@@ -1,0 +1,114 @@
+import dagre from '@dagrejs/dagre'
+import { Position, type Edge, type Node, type NodeHandle } from '@xyflow/react'
+
+export const NODE_WIDTH = 220
+
+/** Header, category chip and padding, before any hyperparameter rows. */
+const NODE_HEADER_HEIGHT = 78
+
+/** One hyperparameter row on the card. */
+const PARAM_ROW_HEIGHT = 16
+
+/** Rows shown on a card before the rest collapse into a "+N more" line. */
+export const MAX_VISIBLE_PARAMS = 4
+
+/** Height grows with the number of hyperparameter rows shown on the node. */
+export const nodeHeight = (paramCount: number): number => {
+  const rows = Math.min(paramCount, MAX_VISIBLE_PARAMS)
+  const overflowRow = paramCount > MAX_VISIBLE_PARAMS ? PARAM_ROW_HEIGHT : 0
+  return NODE_HEADER_HEIGHT + rows * PARAM_ROW_HEIGHT + overflowRow
+}
+
+export type LayoutDirection = 'LR' | 'TB'
+
+/** Size of the connection dots drawn by `PipelineNodeCard`. */
+const HANDLE_SIZE = 9
+
+/**
+ * Where the connection points sit on a node of the given size.
+ *
+ * React Flow normally discovers this by measuring the handle elements once they
+ * are on screen, and refuses to route an edge until it has. Declaring the
+ * geometry up front — it is fixed by the card's own layout — means the edges are
+ * drawn on the first render instead of appearing a frame later, and it keeps the
+ * graph correct in contexts where the resize observer never fires.
+ */
+const handlesFor = (height: number, direction: LayoutDirection): NodeHandle[] => {
+  const horizontal = direction === 'LR'
+  const offset = HANDLE_SIZE / 2
+  return [
+    {
+      type: 'target',
+      position: horizontal ? Position.Left : Position.Top,
+      x: horizontal ? -offset : NODE_WIDTH / 2 - offset,
+      y: horizontal ? height / 2 - offset : -offset,
+      width: HANDLE_SIZE,
+      height: HANDLE_SIZE,
+    },
+    {
+      type: 'source',
+      position: horizontal ? Position.Right : Position.Bottom,
+      x: horizontal ? NODE_WIDTH - offset : NODE_WIDTH / 2 - offset,
+      y: horizontal ? height / 2 - offset : height - offset,
+      width: HANDLE_SIZE,
+      height: HANDLE_SIZE,
+    },
+  ]
+}
+
+/**
+ * Position nodes with dagre.
+ *
+ * FEDOT pipelines flow from data sources to the root predictor, so the default
+ * is left-to-right; forecasting pipelines with long preprocessing chains read
+ * better top-to-bottom, hence the toggle.
+ */
+export function layoutGraph<N extends Node, E extends Edge>(
+  nodes: N[],
+  edges: E[],
+  direction: LayoutDirection = 'LR',
+): N[] {
+  if (nodes.length === 0) return nodes
+
+  const graph = new dagre.graphlib.Graph()
+  graph.setDefaultEdgeLabel(() => ({}))
+  graph.setGraph({
+    rankdir: direction,
+    nodesep: direction === 'LR' ? 28 : 48,
+    ranksep: direction === 'LR' ? 96 : 72,
+    marginx: 24,
+    marginy: 24,
+  })
+
+  for (const node of nodes) {
+    const params = (node.data as { paramCount?: number })?.paramCount ?? 0
+    graph.setNode(node.id, { width: NODE_WIDTH, height: nodeHeight(params) })
+  }
+  for (const edge of edges) {
+    if (graph.hasNode(edge.source) && graph.hasNode(edge.target)) {
+      graph.setEdge(edge.source, edge.target)
+    }
+  }
+
+  dagre.layout(graph)
+
+  return nodes.map((node) => {
+    const positioned = graph.node(node.id)
+    if (!positioned) return node
+    const params = (node.data as { paramCount?: number })?.paramCount ?? 0
+    const height = nodeHeight(params)
+    return {
+      ...node,
+      // dagre reports the centre; React Flow positions by the top-left corner.
+      position: { x: positioned.x - NODE_WIDTH / 2, y: positioned.y - height / 2 },
+      // Declaring the size explicitly means React Flow does not have to wait for
+      // a ResizeObserver before it can route the edges, so the graph is complete
+      // on first paint instead of appearing node-by-node.
+      width: NODE_WIDTH,
+      height,
+      handles: handlesFor(height, direction),
+      targetPosition: direction === 'LR' ? Position.Left : Position.Top,
+      sourcePosition: direction === 'LR' ? Position.Right : Position.Bottom,
+    } as N
+  })
+}

--- a/ui/src/pipeline/paramDisplay.ts
+++ b/ui/src/pipeline/paramDisplay.ts
@@ -43,19 +43,26 @@ export interface VisibleParam {
  *
  * Values the user (or evolution) changed away from the default come first —
  * those are what make one node differ from another in a composed pipeline.
+ * A node with nothing set still runs with FEDOT's defaults (from
+ * `default_operation_params.json`), so those are shown rather than a bare
+ * "default hyperparameters" label that says nothing.
  */
 export function selectVisibleParams(node: Pick<GraphNode, 'params' | 'defaults'>): {
   visible: VisibleParam[]
   hidden: number
   total: number
+  /** True when the rows shown are FEDOT's defaults, not values set on the node. */
+  fromDefaults: boolean
 } {
   const defaults = node.defaults ?? {}
-  const entries = Object.entries(node.params ?? {})
+  const params = node.params ?? {}
+  const hasOwn = Object.keys(params).length > 0
+  const source = hasOwn ? params : defaults
 
-  const annotated: VisibleParam[] = entries.map(([name, value]) => ({
+  const annotated: VisibleParam[] = Object.entries(source).map(([name, value]) => ({
     name,
     value,
-    changed: isChanged(name, value, defaults),
+    changed: hasOwn ? isChanged(name, value, defaults) : false,
   }))
 
   annotated.sort((a, b) => {
@@ -67,6 +74,7 @@ export function selectVisibleParams(node: Pick<GraphNode, 'params' | 'defaults'>
     visible: annotated.slice(0, MAX_VISIBLE_PARAMS),
     hidden: Math.max(0, annotated.length - MAX_VISIBLE_PARAMS),
     total: annotated.length,
+    fromDefaults: !hasOwn && annotated.length > 0,
   }
 }
 

--- a/ui/src/pipeline/paramDisplay.ts
+++ b/ui/src/pipeline/paramDisplay.ts
@@ -1,0 +1,93 @@
+import type { GraphNode, ParameterSchema } from '../api/types'
+import { MAX_VISIBLE_PARAMS } from './layout'
+
+/** Compact rendering of a hyperparameter value for the node card. */
+export function formatParamValue(value: unknown): string {
+  if (value === null || value === undefined) return '—'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') {
+    if (Number.isInteger(value)) return String(value)
+    // Keep very small and very large magnitudes readable.
+    const magnitude = Math.abs(value)
+    if (magnitude !== 0 && (magnitude < 1e-3 || magnitude >= 1e5)) return value.toExponential(2)
+    return String(Number(value.toFixed(4)))
+  }
+  if (Array.isArray(value)) return `[${value.length}]`
+  if (typeof value === 'object') return '{…}'
+  const text = String(value)
+  return text.length > 18 ? `${text.slice(0, 17)}…` : text
+}
+
+const sameValue = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true
+  if (typeof a === 'number' && typeof b === 'number') return Math.abs(a - b) < 1e-12
+  if (a === null || b === null || a === undefined || b === undefined) return false
+  if (typeof a === 'object' && typeof b === 'object') {
+    return JSON.stringify(a) === JSON.stringify(b)
+  }
+  return String(a) === String(b)
+}
+
+/** True when the node overrides FEDOT's default for this parameter. */
+export const isChanged = (name: string, value: unknown, defaults: Record<string, unknown>): boolean =>
+  !(name in defaults) || !sameValue(value, defaults[name])
+
+export interface VisibleParam {
+  name: string
+  value: unknown
+  changed: boolean
+}
+
+/**
+ * Choose which hyperparameters to show on a node card.
+ *
+ * Values the user (or evolution) changed away from the default come first —
+ * those are what make one node differ from another in a composed pipeline.
+ */
+export function selectVisibleParams(node: Pick<GraphNode, 'params' | 'defaults'>): {
+  visible: VisibleParam[]
+  hidden: number
+  total: number
+} {
+  const defaults = node.defaults ?? {}
+  const entries = Object.entries(node.params ?? {})
+
+  const annotated: VisibleParam[] = entries.map(([name, value]) => ({
+    name,
+    value,
+    changed: isChanged(name, value, defaults),
+  }))
+
+  annotated.sort((a, b) => {
+    if (a.changed !== b.changed) return a.changed ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+
+  return {
+    visible: annotated.slice(0, MAX_VISIBLE_PARAMS),
+    hidden: Math.max(0, annotated.length - MAX_VISIBLE_PARAMS),
+    total: annotated.length,
+  }
+}
+
+/**
+ * The value in force for a parameter: what the node sets, or the schema default.
+ */
+export function effectiveValue(
+  schema: ParameterSchema,
+  params: Record<string, unknown>,
+): unknown {
+  return schema.name in params ? params[schema.name] : schema.default
+}
+
+/** Human-readable summary of where a tunable parameter may range. */
+export function describeScope(schema: ParameterSchema): string | null {
+  if (schema.type === 'categorical' && schema.choices) {
+    return `one of ${schema.choices.length}`
+  }
+  if (schema.minimum !== null && schema.maximum !== null) {
+    const scale = schema.log_scale ? ', log scale' : ''
+    return `${formatParamValue(schema.minimum)} … ${formatParamValue(schema.maximum)}${scale}`
+  }
+  return null
+}

--- a/ui/src/runs/EvaluationMonitor.tsx
+++ b/ui/src/runs/EvaluationMonitor.tsx
@@ -1,0 +1,215 @@
+import { useQuery } from '@tanstack/react-query'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+
+import { api } from '../api/client'
+import type { ActiveEvaluation, FinishedEvaluation } from '../api/types'
+
+interface Props {
+  runUid: string
+  /** Total folds from the run config, to render "fold 2 of 3". */
+  cvFolds?: number | null
+}
+
+const mono = '"JetBrains Mono", monospace'
+
+const opsLabel = (ops: string[]): string => (ops.length > 0 ? ops.join(' → ') : 'pipeline')
+
+const fmtSeconds = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) return '—'
+  if (value < 60) return `${Math.round(value)}s`
+  return `${Math.floor(value / 60)}m ${Math.round(value % 60)}s`
+}
+
+function ActiveRow({ item, cvFolds }: { item: ActiveEvaluation; cvFolds?: number | null }) {
+  const theme = useTheme()
+  return (
+    <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>
+      <Box
+        sx={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          flexShrink: 0,
+          bgcolor: theme.palette.success.main,
+          animation: 'evalPulse 1.2s ease-in-out infinite',
+          '@keyframes evalPulse': {
+            '0%': { opacity: 1 },
+            '50%': { opacity: 0.3 },
+            '100%': { opacity: 1 },
+          },
+        }}
+      />
+      <Typography
+        noWrap
+        sx={{ fontFamily: mono, fontSize: '0.78rem', minWidth: 0, flexShrink: 1 }}
+        title={opsLabel(item.ops)}
+      >
+        {opsLabel(item.ops)}
+      </Typography>
+      {item.fold !== null && (
+        <Chip
+          size="small"
+          variant="outlined"
+          label={cvFolds ? `fold ${item.fold + 1}/${cvFolds}` : `fold ${item.fold + 1}`}
+          sx={{ height: 19, fontSize: '0.68rem', flexShrink: 0 }}
+        />
+      )}
+      {item.node && (
+        <Chip
+          size="small"
+          color="success"
+          variant="outlined"
+          label={`fitting ${item.node}`}
+          sx={{ height: 19, fontSize: '0.68rem', flexShrink: 0 }}
+        />
+      )}
+      <Box sx={{ flexGrow: 1 }} />
+      <Typography sx={{ fontSize: '0.72rem', color: 'text.secondary', flexShrink: 0 }}>
+        {fmtSeconds(item.seconds)}
+      </Typography>
+    </Stack>
+  )
+}
+
+function RecentRow({ item }: { item: FinishedEvaluation }) {
+  const theme = useTheme()
+  return (
+    <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>
+      <Box
+        sx={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          flexShrink: 0,
+          bgcolor: item.failed ? theme.palette.error.main : alpha(theme.palette.text.disabled, 0.5),
+        }}
+      />
+      <Typography
+        noWrap
+        sx={{
+          fontFamily: mono,
+          fontSize: '0.78rem',
+          minWidth: 0,
+          color: item.failed ? 'text.disabled' : 'text.primary',
+        }}
+        title={item.error ?? opsLabel(item.ops)}
+      >
+        {opsLabel(item.ops)}
+      </Typography>
+      {item.failed && (
+        <Tooltip title={item.error ?? 'The evaluation failed'}>
+          <Chip size="small" color="error" variant="outlined" label="failed" sx={{ height: 19, fontSize: '0.68rem' }} />
+        </Tooltip>
+      )}
+      <Box sx={{ flexGrow: 1 }} />
+      {item.fitness !== null && (
+        <Typography sx={{ fontFamily: mono, fontSize: '0.72rem', flexShrink: 0 }}>
+          {Number(item.fitness.toFixed(4))}
+        </Typography>
+      )}
+      <Typography sx={{ fontSize: '0.72rem', color: 'text.secondary', flexShrink: 0, width: 52, textAlign: 'right' }}>
+        {fmtSeconds(item.seconds)}
+      </Typography>
+    </Stack>
+  )
+}
+
+/**
+ * What the evaluator is doing right now.
+ *
+ * A generation is minutes of silence in which the actual work happens: each
+ * candidate pipeline is fitted fold after fold, node after node. This panel
+ * shows that work as it goes — which pipelines are being fitted at this
+ * moment, how long each has been going, and what just finished with what
+ * fitness — so a slow run reads as slow *at something*, not stuck.
+ */
+export default function EvaluationMonitor({ runUid, cvFolds }: Props) {
+  const { data } = useQuery({
+    queryKey: ['evaluations', runUid],
+    queryFn: () => api.evaluations(runUid),
+    refetchInterval: 2000,
+  })
+
+  // The panel stays visible from the first second of a run: knowing that
+  // nothing has been reported yet is also status.
+  const { active, preparing, recent, totals } = data ?? {
+    active: [],
+    preparing: null,
+    recent: [],
+    totals: { done: 0, failed: 0, active: 0, mean_seconds: null },
+  }
+  const empty = active.length === 0 && recent.length === 0 && !preparing
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Stack direction="row" alignItems="baseline" spacing={1} sx={{ mb: 1 }}>
+        <Typography variant="subtitle2">Evaluating now</Typography>
+        <Typography variant="caption" color="text.secondary">
+          {totals.done} evaluated
+          {totals.failed > 0 && ` · ${totals.failed} failed`}
+          {totals.mean_seconds !== null && ` · ~${fmtSeconds(totals.mean_seconds)} per pipeline`}
+        </Typography>
+      </Stack>
+
+      <Stack spacing={0.75}>
+        {preparing && (
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Box
+              sx={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                bgcolor: 'info.main',
+                animation: 'evalPulse 1.2s ease-in-out infinite',
+              }}
+            />
+            <Typography sx={{ fontSize: '0.78rem' }}>
+              Fitting outside evolution (initial assumption or final model)
+              {preparing.node && (
+                <Box component="span" sx={{ fontFamily: mono }}>
+                  {' '}
+                  — {preparing.node}
+                </Box>
+              )}
+            </Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <Typography sx={{ fontSize: '0.72rem', color: 'text.secondary' }}>
+              {fmtSeconds(preparing.seconds)}
+            </Typography>
+          </Stack>
+        )}
+
+        {active.map((item, index) => (
+          <ActiveRow key={index} item={item} cvFolds={cvFolds} />
+        ))}
+
+        {active.length === 0 && !preparing && (
+          <Typography variant="caption" color="text.disabled">
+            {empty
+              ? 'Nothing reported yet — the run is starting up. Fits appear here the moment they begin.'
+              : 'Nothing is being fitted right now — the optimiser is between populations.'}
+          </Typography>
+        )}
+      </Stack>
+
+      {recent.length > 0 && (
+        <>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1.5, mb: 0.5 }}>
+            Just finished
+          </Typography>
+          <Stack spacing={0.5}>
+            {recent.slice(0, 6).map((item, index) => (
+              <RecentRow key={index} item={item} />
+            ))}
+          </Stack>
+        </>
+      )}
+    </Paper>
+  )
+}

--- a/ui/src/runs/EvolutionControlPanel.tsx
+++ b/ui/src/runs/EvolutionControlPanel.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Divider from '@mui/material/Divider'
+import Grid from '@mui/material/Grid'
+import Paper from '@mui/material/Paper'
+import Slider from '@mui/material/Slider'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import FlagRoundedIcon from '@mui/icons-material/FlagRounded'
+import RestartAltRoundedIcon from '@mui/icons-material/RestartAltRounded'
+
+import { api } from '../api/client'
+import type { EvolutionControls } from '../api/types'
+
+interface Props {
+  runUid: string
+  /** Bumped by the caller on each new generation, to refresh what is in force. */
+  revision?: number
+}
+
+const number = (value: string): number | null => {
+  if (value.trim() === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const show = (value: number | null | undefined, digits = 2): string =>
+  value === null || value === undefined ? '—' : String(Number(value.toFixed(digits)))
+
+/**
+ * Change how the evolution behaves, without restarting it.
+ *
+ * Requests are picked up by the optimiser between generations, so a generation in
+ * flight is never disturbed — which is why a change shows up in "in force" one
+ * generation after it is sent. Leaving a field empty hands that parameter back to
+ * GOLEM's own adaptive policy.
+ */
+/** Numeric fields, and how long to wait after typing before sending. */
+const NUMERIC_FIELDS = ['pop_size', 'num_of_generations', 'timeout_minutes'] as const
+const COMMIT_DELAY_MS = 700
+
+export default function EvolutionControlPanel({ runUid, revision = 0 }: Props) {
+  const queryClient = useQueryClient()
+  const [draft, setDraft] = useState<Record<string, string>>({})
+  const [error, setError] = useState<string | null>(null)
+
+  const { data: state } = useQuery({
+    queryKey: ['controls', runUid],
+    queryFn: () => api.controls(runUid),
+    staleTime: 0,
+  })
+
+  useEffect(() => {
+    void queryClient.invalidateQueries({ queryKey: ['controls', runUid] })
+  }, [revision, runUid, queryClient])
+
+  const send = useMutation({
+    mutationFn: (patch: Partial<EvolutionControls>) => api.setControls(runUid, patch),
+    onSuccess: (next) => {
+      queryClient.setQueryData(['controls', runUid], next)
+      setError(null)
+    },
+    onError: (sendError: Error) => setError(sendError.message),
+  })
+
+  const requested = state?.requested
+
+  // Committing on a timer rather than on blur: a control panel should act on
+  // what was typed without needing the field to lose focus first, and it makes
+  // the behaviour independent of the render cycle.
+  useEffect(() => {
+    if (!requested || Object.keys(draft).length === 0) return
+    const timer = window.setTimeout(() => {
+      const patch: Partial<EvolutionControls> = {}
+      for (const key of NUMERIC_FIELDS) {
+        const pending = draft[key]
+        if (pending === undefined) continue
+        const parsed = number(pending)
+        if (parsed !== (requested[key] ?? null)) {
+          patch[key] = parsed
+        }
+      }
+      setDraft({})
+      if (Object.keys(patch).length > 0) send.mutate(patch)
+    }, COMMIT_DELAY_MS)
+    return () => window.clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draft, requested])
+
+  if (!state || !requested) return null
+
+  const effective = state.effective
+
+  const apply = (patch: Partial<EvolutionControls>) => {
+    setDraft({})
+    send.mutate(patch)
+  }
+
+  const field = (
+    key: keyof EvolutionControls,
+    label: string,
+    hint: string,
+    inForce: number | null | undefined,
+  ) => {
+    const pending = draft[key]
+    const current = requested[key] as number | null
+    const value = pending !== undefined ? pending : current === null ? '' : String(current)
+    return (
+      <Grid size={{ xs: 6, sm: 4 }}>
+        <Tooltip title={hint}>
+          <TextField
+            size="small"
+            fullWidth
+            type="number"
+            label={label}
+            value={value}
+            placeholder="adaptive"
+            onChange={(event) => setDraft((state) => ({ ...state, [key]: event.target.value }))}
+            helperText={
+              pending !== undefined && number(pending) !== (current ?? null)
+                ? 'sending…'
+                : `in force: ${show(inForce)}`
+            }
+          />
+        </Tooltip>
+      </Grid>
+    )
+  }
+
+  const probability = (
+    key: 'mutation_prob' | 'crossover_prob',
+    label: string,
+    inForce: number | null | undefined,
+  ) => {
+    const current = requested[key]
+    return (
+      <Grid size={{ xs: 12, sm: 6 }}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Typography variant="caption" sx={{ minWidth: 96, color: 'text.secondary' }}>
+            {label}
+          </Typography>
+          <Slider
+            size="small"
+            value={current ?? inForce ?? 0}
+            min={0}
+            max={1}
+            step={0.05}
+            valueLabelDisplay="auto"
+            onChangeCommitted={(_, value) =>
+              apply({ [key]: value as number } as Partial<EvolutionControls>)
+            }
+            sx={{ flexGrow: 1 }}
+          />
+          <Typography
+            variant="caption"
+            sx={{ width: 74, textAlign: 'right', fontFamily: '"JetBrains Mono", monospace' }}
+          >
+            {show(inForce)}
+            {current === null && (
+              <Typography component="span" variant="caption" color="text.disabled">
+                {' '}
+                auto
+              </Typography>
+            )}
+          </Typography>
+        </Stack>
+      </Grid>
+    )
+  }
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <Typography variant="h3">Evolution controls</Typography>
+        {effective && (
+          <Chip size="small" variant="outlined" label={`generation ${effective.generation}`} />
+        )}
+        <Box sx={{ flexGrow: 1 }} />
+        <Tooltip title="Hand every parameter back to GOLEM's adaptive policy">
+          <Button
+            size="small"
+            startIcon={<RestartAltRoundedIcon />}
+            onClick={() =>
+              apply({
+                pop_size: null,
+                num_of_generations: null,
+                timeout_minutes: null,
+                mutation_prob: null,
+                crossover_prob: null,
+              })
+            }
+          >
+            Reset
+          </Button>
+        </Tooltip>
+        <Tooltip title="Stop after the current generation and keep the best pipeline found so far. Unlike Stop, the result is fitted and saved.">
+          <Button
+            size="small"
+            color="warning"
+            variant="outlined"
+            startIcon={<FlagRoundedIcon />}
+            onClick={() => apply({ finish_now: true })}
+          >
+            Finish now
+          </Button>
+        </Tooltip>
+      </Stack>
+
+      <Typography variant="caption" color="text.secondary">
+        Changes are picked up between generations — a generation already running is never
+        disturbed. An empty field means GOLEM decides.
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mt: 1 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <Grid container spacing={2} sx={{ mt: 0.5 }}>
+        {field(
+          'pop_size',
+          'Population size',
+          'How many pipelines each generation holds. GOLEM grows this on its own unless pinned.',
+          effective?.pop_size,
+        )}
+        {field(
+          'num_of_generations',
+          'Generation limit',
+          'The run stops once this many generations have been evaluated.',
+          effective?.num_of_generations,
+        )}
+        {field(
+          'timeout_minutes',
+          'Time budget, min',
+          'Total composition budget. Raising it mid-run buys more generations.',
+          effective?.timeout_minutes,
+        )}
+      </Grid>
+
+      <Divider sx={{ my: 1.5 }} />
+
+      <Grid container spacing={2}>
+        {probability('mutation_prob', 'Mutation', effective?.mutation_prob)}
+        {probability('crossover_prob', 'Crossover', effective?.crossover_prob)}
+      </Grid>
+
+      {state.applied.length > 0 && (
+        <Alert severity="success" variant="outlined" sx={{ mt: 1.5, py: 0.2 }}>
+          {state.applied.join(' · ')}
+        </Alert>
+      )}
+    </Paper>
+  )
+}

--- a/ui/src/runs/FitnessChart.tsx
+++ b/ui/src/runs/FitnessChart.tsx
@@ -84,11 +84,28 @@ export default function FitnessChart({ generations, height = 260 }: Props) {
     })
   }, [generations])
 
+  // In best-only mode the trailing plateau is cut: generations where the best
+  // never improved again stretch the axis while showing a flat line.
+  const visible = useMemo<ChartPoint[]>(() => {
+    if (showPopulation) return data
+    let best = Infinity
+    let lastImprovement = -1
+    data.forEach((point, index) => {
+      if (point.best !== null && point.best < best) {
+        best = point.best
+        lastImprovement = index
+      }
+    })
+    if (lastImprovement < 0) return data
+    return data.slice(0, lastImprovement + 1)
+  }, [data, showPopulation])
+  const hiddenTail = data.length - visible.length
+
   // In best-only mode the axis hugs the best curve; population mode needs the
   // full range for the band.
   const domain = useMemo<[number | string, number | string]>(() => {
     if (showPopulation) return ['auto', 'auto']
-    const values = data
+    const values = visible
       .map((point) => point.best)
       .filter((value): value is number => value !== null && Number.isFinite(value))
     if (values.length === 0) return ['auto', 'auto']
@@ -96,7 +113,7 @@ export default function FitnessChart({ generations, height = 260 }: Props) {
     const high = Math.max(...values)
     const pad = (high - low) * 0.15 || Math.abs(high) * 0.002 || 0.001
     return [low - pad, high + pad]
-  }, [data, showPopulation])
+  }, [visible, showPopulation])
 
   if (generations.length === 0) {
     return (
@@ -186,6 +203,7 @@ export default function FitnessChart({ generations, height = 260 }: Props) {
             ●
           </Box>{' '}
           marks a change of the leading pipeline.
+          {hiddenTail > 0 && ` ${hiddenTail} trailing generations without improvement are hidden.`}
         </Typography>
         <Tooltip title="Also draw the population mean and the best-worst band. The band is far wider than the best curve, so the axis zooms out with it.">
           <FormControlLabel
@@ -208,7 +226,7 @@ export default function FitnessChart({ generations, height = 260 }: Props) {
 
       <Box sx={{ height }}>
         <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart data={data} margin={{ top: 8, right: 12, bottom: 4, left: 4 }}>
+          <ComposedChart data={visible} margin={{ top: 8, right: 12, bottom: 4, left: 4 }}>
             <CartesianGrid stroke={theme.palette.divider} strokeDasharray="3 3" vertical={false} />
             <XAxis
               dataKey="generation"

--- a/ui/src/runs/FitnessChart.tsx
+++ b/ui/src/runs/FitnessChart.tsx
@@ -1,0 +1,127 @@
+import { useTheme } from '@mui/material/styles'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import type { GenerationPoint } from '../api/types'
+
+interface Props {
+  generations: GenerationPoint[]
+  height?: number
+}
+
+/**
+ * Fitness across generations.
+ *
+ * GOLEM minimises internally, so a *lower* value is better; the axis is
+ * inverted to keep the familiar "up and to the right means improving" reading.
+ */
+export default function FitnessChart({ generations, height = 260 }: Props) {
+  const theme = useTheme()
+
+  if (generations.length === 0) {
+    return (
+      <Box sx={{ height, display: 'grid', placeItems: 'center' }}>
+        <Typography variant="body2" color="text.disabled">
+          Waiting for the first generation…
+        </Typography>
+      </Box>
+    )
+  }
+
+  const data = generations.map((point) => ({
+    generation: point.generation,
+    best: point.best_fitness,
+    mean: point.mean_fitness,
+    worst: point.worst_fitness,
+    // The band between best and worst shows how converged the population is.
+    spread:
+      point.best_fitness !== null && point.worst_fitness !== null
+        ? [point.best_fitness, point.worst_fitness]
+        : null,
+    size: point.size,
+  }))
+
+  return (
+    <Box sx={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data} margin={{ top: 8, right: 12, bottom: 4, left: 4 }}>
+          <CartesianGrid stroke={theme.palette.divider} strokeDasharray="3 3" vertical={false} />
+          <XAxis
+            dataKey="generation"
+            tick={{ fill: theme.palette.text.secondary, fontSize: 11 }}
+            stroke={theme.palette.divider}
+            label={{
+              value: 'generation',
+              position: 'insideBottom',
+              offset: -2,
+              fill: theme.palette.text.disabled,
+              fontSize: 11,
+            }}
+          />
+          <YAxis
+            reversed
+            tick={{ fill: theme.palette.text.secondary, fontSize: 11 }}
+            stroke={theme.palette.divider}
+            width={62}
+            domain={['auto', 'auto']}
+            tickFormatter={(value: number) =>
+              Math.abs(value) >= 1000 || (Math.abs(value) < 0.01 && value !== 0)
+                ? value.toExponential(1)
+                : String(Number(value.toFixed(4)))
+            }
+          />
+          <Tooltip
+            contentStyle={{
+              background: theme.palette.background.paper,
+              border: `1px solid ${theme.palette.divider}`,
+              borderRadius: 8,
+              fontSize: 12,
+            }}
+            labelFormatter={(label) => `Generation ${label}`}
+            formatter={(value: unknown, key: string) => {
+              if (Array.isArray(value)) return [`${value[0]} … ${value[1]}`, 'population range']
+              return [typeof value === 'number' ? Number(value.toFixed(5)) : String(value), key]
+            }}
+          />
+          <Area
+            dataKey="spread"
+            stroke="none"
+            fill={theme.palette.primary.main}
+            fillOpacity={0.11}
+            isAnimationActive={false}
+            connectNulls
+          />
+          <Line
+            type="monotone"
+            dataKey="mean"
+            stroke={theme.palette.text.disabled}
+            strokeWidth={1.2}
+            strokeDasharray="4 3"
+            dot={false}
+            isAnimationActive={false}
+            connectNulls
+          />
+          <Line
+            type="monotone"
+            dataKey="best"
+            stroke={theme.palette.primary.main}
+            strokeWidth={2.2}
+            dot={{ r: 2.5 }}
+            isAnimationActive={false}
+            connectNulls
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </Box>
+  )
+}

--- a/ui/src/runs/FitnessChart.tsx
+++ b/ui/src/runs/FitnessChart.tsx
@@ -89,8 +89,11 @@ export default function FitnessChart({ generations, height = 260 }: Props) {
             }}
             labelFormatter={(label) => `Generation ${label}`}
             formatter={(value: unknown, key: string) => {
-              if (Array.isArray(value)) return [`${value[0]} … ${value[1]}`, 'population range']
-              return [typeof value === 'number' ? Number(value.toFixed(5)) : String(value), key]
+              if (Array.isArray(value)) {
+                const [low, high] = value as [number, number]
+                return [`${Number(low.toFixed(4))} … ${Number(high.toFixed(4))}`, 'population range']
+              }
+              return [typeof value === 'number' ? Number(value.toFixed(4)) : String(value), key]
             }}
           />
           <Area

--- a/ui/src/runs/FitnessChart.tsx
+++ b/ui/src/runs/FitnessChart.tsx
@@ -1,5 +1,10 @@
+import { useMemo, useState } from 'react'
 import { useTheme } from '@mui/material/styles'
 import Box from '@mui/material/Box'
+import Checkbox from '@mui/material/Checkbox'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import {
   Area,
@@ -7,7 +12,7 @@ import {
   ComposedChart,
   Line,
   ResponsiveContainer,
-  Tooltip,
+  Tooltip as ChartTooltip,
   XAxis,
   YAxis,
 } from 'recharts'
@@ -19,14 +24,79 @@ interface Props {
   height?: number
 }
 
+const fmt = (value: number | null | undefined): string =>
+  value === null || value === undefined ? '—' : String(Number(value.toFixed(4)))
+
+interface ChartPoint {
+  generation: number
+  best: number | null
+  mean: number | null
+  spread: [number, number] | null
+  size: number
+  operations: string
+  /** The champion of this generation is a different individual than before. */
+  leaderChanged: boolean
+  /** ...and its structure differs too (not only hyperparameters). */
+  structureChanged: boolean
+}
+
 /**
  * Fitness across generations.
  *
  * GOLEM minimises internally, so a *lower* value is better; the axis is
  * inverted to keep the familiar "up and to the right means improving" reading.
+ *
+ * By default only the best-fitness curve is drawn, scaled to its own range —
+ * the population spread is an order of magnitude wider and flattens the
+ * interesting curve into a straight line (exactly what the checkbox is for).
+ * Dots mark the generations where the leading pipeline actually changed.
  */
 export default function FitnessChart({ generations, height = 260 }: Props) {
   const theme = useTheme()
+  const [showPopulation, setShowPopulation] = useState(false)
+
+  const data = useMemo<ChartPoint[]>(() => {
+    let previousUid: string | undefined
+    let previousOps: string | undefined
+    return generations.map((point) => {
+      const uid = point.best_uid ?? null
+      const ops = (point.best_operations ?? []).join(' → ')
+      // The first generation establishes a leader rather than changing one.
+      const leaderChanged = uid !== null && previousUid !== undefined && uid !== previousUid
+      const structureChanged = leaderChanged && ops !== previousOps
+      if (uid !== null) {
+        previousUid = uid
+        previousOps = ops
+      }
+      return {
+        generation: point.generation,
+        best: point.best_fitness,
+        mean: point.mean_fitness,
+        spread:
+          point.best_fitness !== null && point.worst_fitness !== null
+            ? ([point.best_fitness, point.worst_fitness] as [number, number])
+            : null,
+        size: point.size,
+        operations: ops,
+        leaderChanged,
+        structureChanged,
+      }
+    })
+  }, [generations])
+
+  // In best-only mode the axis hugs the best curve; population mode needs the
+  // full range for the band.
+  const domain = useMemo<[number | string, number | string]>(() => {
+    if (showPopulation) return ['auto', 'auto']
+    const values = data
+      .map((point) => point.best)
+      .filter((value): value is number => value !== null && Number.isFinite(value))
+    if (values.length === 0) return ['auto', 'auto']
+    const low = Math.min(...values)
+    const high = Math.max(...values)
+    const pad = (high - low) * 0.15 || Math.abs(high) * 0.002 || 0.001
+    return [low - pad, high + pad]
+  }, [data, showPopulation])
 
   if (generations.length === 0) {
     return (
@@ -38,93 +108,167 @@ export default function FitnessChart({ generations, height = 260 }: Props) {
     )
   }
 
-  const data = generations.map((point) => ({
-    generation: point.generation,
-    best: point.best_fitness,
-    mean: point.mean_fitness,
-    worst: point.worst_fitness,
-    // The band between best and worst shows how converged the population is.
-    spread:
-      point.best_fitness !== null && point.worst_fitness !== null
-        ? [point.best_fitness, point.worst_fitness]
-        : null,
-    size: point.size,
-  }))
+  const changeColor = theme.palette.warning.main
+
+  const renderDot = (props: { cx?: number; cy?: number; payload?: ChartPoint; index?: number }) => {
+    const { cx, cy, payload, index } = props
+    if (cx === undefined || cy === undefined || !payload) return <g key={index} />
+    if (payload.leaderChanged) {
+      return (
+        <circle
+          key={index}
+          cx={cx}
+          cy={cy}
+          r={payload.structureChanged ? 5 : 4}
+          fill={changeColor}
+          stroke={theme.palette.background.paper}
+          strokeWidth={1.5}
+        />
+      )
+    }
+    return <circle key={index} cx={cx} cy={cy} r={2} fill={theme.palette.primary.main} />
+  }
+
+  const TipContent = ({
+    active,
+    payload,
+  }: {
+    active?: boolean
+    payload?: { payload: ChartPoint }[]
+  }) => {
+    if (!active || !payload?.length) return null
+    const point = payload[0].payload
+    return (
+      <Box
+        sx={{
+          bgcolor: 'background.paper',
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          px: 1.3,
+          py: 0.9,
+          fontSize: 12,
+          maxWidth: 340,
+        }}
+      >
+        <Typography sx={{ fontSize: 12, fontWeight: 700 }}>
+          Generation {point.generation}
+        </Typography>
+        <div>best {fmt(point.best)}</div>
+        {showPopulation && point.mean !== null && <div>mean {fmt(point.mean)}</div>}
+        {showPopulation && point.spread && (
+          <div>
+            range {fmt(point.spread[0])} … {fmt(point.spread[1])} over {point.size}
+          </div>
+        )}
+        {point.operations && (
+          <Typography sx={{ fontSize: 11, color: 'text.secondary', mt: 0.4 }}>
+            {point.operations}
+          </Typography>
+        )}
+        {point.leaderChanged && (
+          <Typography sx={{ fontSize: 11, color: changeColor, mt: 0.2 }}>
+            {point.structureChanged
+              ? 'new best pipeline (structure changed)'
+              : 'new best pipeline (same structure, other hyperparameters)'}
+          </Typography>
+        )}
+      </Box>
+    )
+  }
 
   return (
-    <Box sx={{ height }}>
-      <ResponsiveContainer width="100%" height="100%">
-        <ComposedChart data={data} margin={{ top: 8, right: 12, bottom: 4, left: 4 }}>
-          <CartesianGrid stroke={theme.palette.divider} strokeDasharray="3 3" vertical={false} />
-          <XAxis
-            dataKey="generation"
-            tick={{ fill: theme.palette.text.secondary, fontSize: 11 }}
-            stroke={theme.palette.divider}
-            label={{
-              value: 'generation',
-              position: 'insideBottom',
-              offset: -2,
-              fill: theme.palette.text.disabled,
-              fontSize: 11,
-            }}
-          />
-          <YAxis
-            reversed
-            tick={{ fill: theme.palette.text.secondary, fontSize: 11 }}
-            stroke={theme.palette.divider}
-            width={62}
-            domain={['auto', 'auto']}
-            tickFormatter={(value: number) =>
-              Math.abs(value) >= 1000 || (Math.abs(value) < 0.01 && value !== 0)
-                ? value.toExponential(1)
-                : String(Number(value.toFixed(4)))
+    <Box>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.25 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ flexGrow: 1 }}>
+          Lower is better, so the axis is inverted.{' '}
+          <Box component="span" sx={{ color: changeColor }}>
+            ●
+          </Box>{' '}
+          marks a change of the leading pipeline.
+        </Typography>
+        <Tooltip title="Also draw the population mean and the best-worst band. The band is far wider than the best curve, so the axis zooms out with it.">
+          <FormControlLabel
+            sx={{ mr: 0 }}
+            control={
+              <Checkbox
+                size="small"
+                checked={showPopulation}
+                onChange={(event) => setShowPopulation(event.target.checked)}
+              />
+            }
+            label={
+              <Typography variant="caption" color="text.secondary">
+                population mean &amp; spread
+              </Typography>
             }
           />
-          <Tooltip
-            contentStyle={{
-              background: theme.palette.background.paper,
-              border: `1px solid ${theme.palette.divider}`,
-              borderRadius: 8,
-              fontSize: 12,
-            }}
-            labelFormatter={(label) => `Generation ${label}`}
-            formatter={(value: unknown, key: string) => {
-              if (Array.isArray(value)) {
-                const [low, high] = value as [number, number]
-                return [`${Number(low.toFixed(4))} … ${Number(high.toFixed(4))}`, 'population range']
+        </Tooltip>
+      </Stack>
+
+      <Box sx={{ height }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={data} margin={{ top: 8, right: 12, bottom: 4, left: 4 }}>
+            <CartesianGrid stroke={theme.palette.divider} strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="generation"
+              tick={{ fill: theme.palette.text.secondary, fontSize: 11 }}
+              stroke={theme.palette.divider}
+              label={{
+                value: 'generation',
+                position: 'insideBottom',
+                offset: -2,
+                fill: theme.palette.text.disabled,
+                fontSize: 11,
+              }}
+            />
+            <YAxis
+              reversed
+              tick={{ fill: theme.palette.text.secondary, fontSize: 11 }}
+              stroke={theme.palette.divider}
+              width={68}
+              domain={domain as [number, number]}
+              tickFormatter={(value: number) =>
+                Math.abs(value) >= 1000 || (Math.abs(value) < 0.01 && value !== 0)
+                  ? value.toExponential(1)
+                  : String(Number(value.toFixed(4)))
               }
-              return [typeof value === 'number' ? Number(value.toFixed(4)) : String(value), key]
-            }}
-          />
-          <Area
-            dataKey="spread"
-            stroke="none"
-            fill={theme.palette.primary.main}
-            fillOpacity={0.11}
-            isAnimationActive={false}
-            connectNulls
-          />
-          <Line
-            type="monotone"
-            dataKey="mean"
-            stroke={theme.palette.text.disabled}
-            strokeWidth={1.2}
-            strokeDasharray="4 3"
-            dot={false}
-            isAnimationActive={false}
-            connectNulls
-          />
-          <Line
-            type="monotone"
-            dataKey="best"
-            stroke={theme.palette.primary.main}
-            strokeWidth={2.2}
-            dot={{ r: 2.5 }}
-            isAnimationActive={false}
-            connectNulls
-          />
-        </ComposedChart>
-      </ResponsiveContainer>
+            />
+            <ChartTooltip content={<TipContent />} />
+            {showPopulation && (
+              <Area
+                dataKey="spread"
+                stroke="none"
+                fill={theme.palette.primary.main}
+                fillOpacity={0.11}
+                isAnimationActive={false}
+                connectNulls
+              />
+            )}
+            {showPopulation && (
+              <Line
+                type="monotone"
+                dataKey="mean"
+                stroke={theme.palette.text.disabled}
+                strokeWidth={1.2}
+                strokeDasharray="4 3"
+                dot={false}
+                isAnimationActive={false}
+                connectNulls
+              />
+            )}
+            <Line
+              type="monotone"
+              dataKey="best"
+              stroke={theme.palette.primary.main}
+              strokeWidth={2.2}
+              dot={renderDot}
+              isAnimationActive={false}
+              connectNulls
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </Box>
     </Box>
   )
 }

--- a/ui/src/runs/RunConfigForm.tsx
+++ b/ui/src/runs/RunConfigForm.tsx
@@ -1,0 +1,379 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import Accordion from '@mui/material/Accordion'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Grid from '@mui/material/Grid'
+import MenuItem from '@mui/material/MenuItem'
+import Slider from '@mui/material/Slider'
+import Stack from '@mui/material/Stack'
+import Switch from '@mui/material/Switch'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
+
+import { api } from '../api/client'
+import type { PipelineGraph, Problem, RunConfig } from '../api/types'
+
+interface Props {
+  value: RunConfig
+  onChange: (config: RunConfig) => void
+  initialPipeline?: PipelineGraph | null
+}
+
+export const defaultRunConfig = (datasetUid = ''): RunConfig => ({
+  problem: 'classification',
+  dataset_uid: datasetUid,
+  target: null,
+  timeout: 5,
+  preset: 'auto',
+  metric: null,
+  seed: 42,
+  n_jobs: 1,
+  cv_folds: 5,
+  pop_size: 20,
+  num_of_generations: 20,
+  max_depth: 6,
+  max_arity: 4,
+  with_tuning: true,
+  early_stopping_iterations: null,
+  available_operations: null,
+  forecast_length: 30,
+  initial_pipeline: null,
+  logging_level: 20,
+})
+
+/**
+ * The run-configuration form.
+ *
+ * Every field maps onto a parameter of `Fedot(...)`, which is what turns this
+ * from a viewer into a control panel for the framework: the same knobs a script
+ * would set are available here, with the choices FEDOT itself reports.
+ */
+export default function RunConfigForm({ value, onChange, initialPipeline }: Props) {
+  const [expanded, setExpanded] = useState(false)
+
+  const { data: capabilities } = useQuery({
+    queryKey: ['capabilities'],
+    queryFn: api.capabilities,
+    staleTime: Infinity,
+  })
+
+  const { data: datasets = [] } = useQuery({ queryKey: ['datasets'], queryFn: api.datasets })
+
+  const dataset = datasets.find((item) => item.uid === value.dataset_uid) ?? null
+
+  const metrics = useMemo(
+    () =>
+      (capabilities?.metrics ?? []).filter(
+        (metric) => metric.tasks.length === 0 || metric.tasks.includes(value.problem),
+      ),
+    [capabilities, value.problem],
+  )
+
+  const set = <K extends keyof RunConfig>(key: K, next: RunConfig[K]) =>
+    onChange({ ...value, [key]: next })
+
+  // A metric chosen for one task rarely applies to another.
+  useEffect(() => {
+    if (value.metric && !metrics.some((metric) => metric.id === value.metric)) {
+      onChange({ ...value, metric: null })
+    }
+  }, [metrics, value, onChange])
+
+  // Adopt the dataset's own target and task when one is picked.
+  useEffect(() => {
+    if (!dataset) return
+    const patch: Partial<RunConfig> = {}
+    if (!value.target && dataset.target) patch.target = dataset.target
+    if (dataset.task && dataset.task !== value.problem) patch.problem = dataset.task as Problem
+    if (Object.keys(patch).length) onChange({ ...value, ...patch })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataset?.uid])
+
+  return (
+    <Stack spacing={2}>
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            label="Dataset"
+            value={value.dataset_uid}
+            onChange={(event) => set('dataset_uid', event.target.value)}
+            helperText={dataset ? `${dataset.n_rows ?? '?'} rows` : 'Upload a dataset first'}
+          >
+            {datasets.map((item) => (
+              <MenuItem key={item.uid} value={item.uid}>
+                {item.name}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            label="Target column"
+            value={value.target ?? ''}
+            onChange={(event) => set('target', event.target.value)}
+            disabled={!dataset}
+          >
+            {(dataset?.columns ?? []).map((column) => (
+              <MenuItem key={column.name} value={column.name}>
+                {column.name} · {column.type}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+
+        <Grid size={{ xs: 12, sm: 4 }}>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            label="Task"
+            value={value.problem}
+            onChange={(event) => set('problem', event.target.value as Problem)}
+          >
+            {(capabilities?.tasks ?? [])
+              .filter((task) => task.id !== 'clustering')
+              .map((task) => (
+                <MenuItem key={task.id} value={task.id}>
+                  {task.label}
+                </MenuItem>
+              ))}
+          </TextField>
+        </Grid>
+
+        <Grid size={{ xs: 12, sm: 4 }}>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            label="Preset"
+            value={value.preset}
+            onChange={(event) => set('preset', event.target.value)}
+            helperText={
+              capabilities?.presets.find((preset) => preset.id === value.preset)?.description
+            }
+          >
+            {(capabilities?.presets ?? []).map((preset) => (
+              <MenuItem key={preset.id} value={preset.id}>
+                {preset.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+
+        <Grid size={{ xs: 12, sm: 4 }}>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            label="Metric"
+            value={value.metric ?? ''}
+            onChange={(event) => set('metric', event.target.value || null)}
+            helperText="Leave empty to use FEDOT's default for the task"
+          >
+            <MenuItem value="">Default</MenuItem>
+            {metrics.map((metric) => (
+              <MenuItem key={metric.id} value={metric.id}>
+                {metric.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+
+        <Grid size={12}>
+          <Typography variant="caption" color="text.secondary">
+            Time budget — {value.timeout} minute{value.timeout === 1 ? '' : 's'}
+          </Typography>
+          <Slider
+            size="small"
+            value={value.timeout}
+            min={0.5}
+            max={Math.min(120, capabilities?.max_run_timeout_minutes ?? 120)}
+            step={0.5}
+            marks={[
+              { value: 1, label: '1m' },
+              { value: 15, label: '15m' },
+              { value: 60, label: '1h' },
+            ]}
+            onChange={(_, next) => set('timeout', next as number)}
+            valueLabelDisplay="auto"
+          />
+        </Grid>
+
+        {value.problem === 'ts_forecasting' && (
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Forecast horizon"
+              value={value.forecast_length}
+              onChange={(event) => set('forecast_length', Number(event.target.value))}
+              helperText="Number of future steps to predict"
+            />
+          </Grid>
+        )}
+      </Grid>
+
+      {initialPipeline && initialPipeline.nodes.length > 0 && (
+        <Alert severity="info" variant="outlined">
+          Evolution will start from your pipeline ({initialPipeline.nodes.length} nodes) instead of
+          FEDOT's default assumption.
+        </Alert>
+      )}
+
+      <Accordion
+        expanded={expanded}
+        onChange={(_, isExpanded) => setExpanded(isExpanded)}
+        disableGutters
+        variant="outlined"
+      >
+        <AccordionSummary expandIcon={<ExpandMoreRoundedIcon />}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="subtitle2">Evolution parameters</Typography>
+            <Chip
+              size="small"
+              variant="outlined"
+              label={`pop ${value.pop_size} · gen ${value.num_of_generations}`}
+            />
+          </Stack>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 6, sm: 3 }}>
+              <Tooltip title="Number of pipelines held in each generation">
+                <TextField
+                  fullWidth
+                  size="small"
+                  type="number"
+                  label="Population size"
+                  value={value.pop_size}
+                  onChange={(event) => set('pop_size', Number(event.target.value))}
+                />
+              </Tooltip>
+            </Grid>
+            <Grid size={{ xs: 6, sm: 3 }}>
+              <TextField
+                fullWidth
+                size="small"
+                type="number"
+                label="Generations"
+                value={value.num_of_generations}
+                onChange={(event) => set('num_of_generations', Number(event.target.value))}
+              />
+            </Grid>
+            <Grid size={{ xs: 6, sm: 3 }}>
+              <Tooltip title="Longest chain of operations a pipeline may have">
+                <TextField
+                  fullWidth
+                  size="small"
+                  type="number"
+                  label="Max depth"
+                  value={value.max_depth}
+                  onChange={(event) => set('max_depth', Number(event.target.value))}
+                />
+              </Tooltip>
+            </Grid>
+            <Grid size={{ xs: 6, sm: 3 }}>
+              <Tooltip title="Most parents a single node may take">
+                <TextField
+                  fullWidth
+                  size="small"
+                  type="number"
+                  label="Max arity"
+                  value={value.max_arity}
+                  onChange={(event) => set('max_arity', Number(event.target.value))}
+                />
+              </Tooltip>
+            </Grid>
+
+            <Grid size={{ xs: 6, sm: 3 }}>
+              <TextField
+                fullWidth
+                size="small"
+                type="number"
+                label="CV folds"
+                value={value.cv_folds}
+                onChange={(event) => set('cv_folds', Number(event.target.value))}
+              />
+            </Grid>
+            <Grid size={{ xs: 6, sm: 3 }}>
+              <Tooltip title="Stop early after this many generations without improvement">
+                <TextField
+                  fullWidth
+                  size="small"
+                  type="number"
+                  label="Early stopping"
+                  value={value.early_stopping_iterations ?? ''}
+                  onChange={(event) =>
+                    set(
+                      'early_stopping_iterations',
+                      event.target.value ? Number(event.target.value) : null,
+                    )
+                  }
+                />
+              </Tooltip>
+            </Grid>
+            <Grid size={{ xs: 6, sm: 3 }}>
+              <TextField
+                fullWidth
+                size="small"
+                type="number"
+                label="Parallel jobs"
+                value={value.n_jobs}
+                onChange={(event) => set('n_jobs', Number(event.target.value))}
+                helperText="-1 uses every core"
+              />
+            </Grid>
+            <Grid size={{ xs: 6, sm: 3 }}>
+              <TextField
+                fullWidth
+                size="small"
+                type="number"
+                label="Seed"
+                value={value.seed ?? ''}
+                onChange={(event) =>
+                  set('seed', event.target.value ? Number(event.target.value) : null)
+                }
+                helperText="Fixes the run for reproducibility"
+              />
+            </Grid>
+
+            <Grid size={12}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    size="small"
+                    checked={value.with_tuning}
+                    onChange={(event) => set('with_tuning', event.target.checked)}
+                  />
+                }
+                label={
+                  <Box>
+                    <Typography variant="body2">Tune hyperparameters after composition</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Runs the FEDOT tuner over the best pipeline within the same time budget
+                    </Typography>
+                  </Box>
+                }
+              />
+            </Grid>
+          </Grid>
+        </AccordionDetails>
+      </Accordion>
+    </Stack>
+  )
+}

--- a/ui/src/runs/useRunStream.ts
+++ b/ui/src/runs/useRunStream.ts
@@ -67,6 +67,11 @@ export function useRunStream(uid: string | undefined, enabled: boolean): RunStre
               mean_fitness: (payload.mean_fitness as number | undefined) ?? null,
               worst_fitness: (payload.worst_fitness as number | undefined) ?? null,
               elapsed: event.elapsed ?? null,
+              best_uid:
+                ((payload.best_pipeline as { uid?: string } | null)?.uid ?? null) || null,
+              best_operations: (
+                (payload.best_pipeline as { nodes?: { operation?: string }[] } | null)?.nodes ?? []
+              ).map((node) => String(node.operation ?? '')),
             }
             // Replays can repeat a generation; keep one entry per index.
             const generations = current.generations.filter(

--- a/ui/src/runs/useRunStream.ts
+++ b/ui/src/runs/useRunStream.ts
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { openRunStream } from '../api/client'
+import type { GenerationPoint, PipelineGraph, RunEvent } from '../api/types'
+
+export interface RunStreamState {
+  connected: boolean
+  generations: GenerationPoint[]
+  bestPipeline: PipelineGraph | null
+  logs: { message: string; level: string; elapsed?: number | null }[]
+  status: string | null
+  elapsed: number | null
+}
+
+const EMPTY: RunStreamState = {
+  connected: false,
+  generations: [],
+  bestPipeline: null,
+  logs: [],
+  status: null,
+  elapsed: null,
+}
+
+/**
+ * Follow a run's progress over a WebSocket.
+ *
+ * The server replays every stored event on connect, so the hook rebuilds the
+ * full fitness curve from scratch — a reload or a late-opened tab shows the same
+ * picture as one that watched from the start.
+ */
+export function useRunStream(uid: string | undefined, enabled: boolean): RunStreamState {
+  const [state, setState] = useState<RunStreamState>(EMPTY)
+  const socketRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    if (!uid || !enabled) {
+      setState(EMPTY)
+      return
+    }
+
+    setState(EMPTY)
+    let closed = false
+    const socket = openRunStream(uid)
+    socketRef.current = socket
+
+    socket.onopen = () => {
+      if (!closed) setState((current) => ({ ...current, connected: true }))
+    }
+
+    socket.onmessage = (message) => {
+      let event: RunEvent
+      try {
+        event = JSON.parse(message.data as string)
+      } catch {
+        return
+      }
+      if (event.kind === 'ping') return
+
+      setState((current) => {
+        const payload = event.payload ?? {}
+        switch (event.kind) {
+          case 'generation': {
+            const point: GenerationPoint = {
+              generation: Number(payload.generation ?? current.generations.length),
+              size: Number(payload.size ?? 0),
+              best_fitness: (payload.best_fitness as number | undefined) ?? null,
+              mean_fitness: (payload.mean_fitness as number | undefined) ?? null,
+              worst_fitness: (payload.worst_fitness as number | undefined) ?? null,
+              elapsed: event.elapsed ?? null,
+            }
+            // Replays can repeat a generation; keep one entry per index.
+            const generations = current.generations.filter(
+              (existing) => existing.generation !== point.generation,
+            )
+            generations.push(point)
+            generations.sort((a, b) => a.generation - b.generation)
+
+            return {
+              ...current,
+              generations,
+              elapsed: event.elapsed ?? current.elapsed,
+              bestPipeline: (payload.best_pipeline as PipelineGraph | null) ?? current.bestPipeline,
+            }
+          }
+          case 'status':
+          case 'run_status':
+            return { ...current, status: String(payload.status ?? current.status) }
+          case 'log':
+            return {
+              ...current,
+              logs: [
+                ...current.logs.slice(-199),
+                {
+                  message: String(payload.message ?? ''),
+                  level: String(payload.level ?? 'info'),
+                  elapsed: event.elapsed ?? null,
+                },
+              ],
+            }
+          case 'error':
+            return {
+              ...current,
+              status: 'failed',
+              logs: [
+                ...current.logs.slice(-199),
+                { message: String(payload.message ?? 'Run failed'), level: 'error' },
+              ],
+            }
+          case 'finished':
+            return { ...current, status: 'finished' }
+          case 'cancelled':
+            return { ...current, status: 'cancelled' }
+          default:
+            return current
+        }
+      })
+    }
+
+    const markDisconnected = () => {
+      if (!closed) setState((current) => ({ ...current, connected: false }))
+    }
+    socket.onclose = markDisconnected
+    socket.onerror = markDisconnected
+
+    return () => {
+      closed = true
+      socketRef.current = null
+      // Only close a socket that finished opening; closing during CONNECTING
+      // produces a console error in some browsers.
+      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CLOSING) {
+        socket.close()
+      } else {
+        socket.addEventListener('open', () => socket.close(), { once: true })
+      }
+    }
+  }, [uid, enabled])
+
+  return state
+}

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -1,0 +1,82 @@
+import { createTheme, type Theme } from '@mui/material/styles'
+
+/**
+ * Colours used to distinguish operation groups on the pipeline canvas.
+ *
+ * They double as the legend, so they need to stay distinguishable in both
+ * themes and reasonably far apart for viewers with colour vision deficiency.
+ */
+export const GROUP_COLORS: Record<string, string> = {
+  source: '#7e57c2',
+  preprocessing: '#26a69a',
+  feature_engineering: '#29b6f6',
+  ts_transform: '#ab47bc',
+  ts_model: '#ec407a',
+  linear: '#42a5f5',
+  non_linear: '#5c6bc0',
+  tree: '#66bb6a',
+  ensemble: '#ffa726',
+  deep: '#ef5350',
+  model: '#8d6e63',
+  data_operation: '#78909c',
+}
+
+export const groupColor = (group?: string): string =>
+  (group && GROUP_COLORS[group]) || GROUP_COLORS.model
+
+const shared = {
+  shape: { borderRadius: 10 },
+  typography: {
+    fontFamily: '"Inter", "Segoe UI", system-ui, sans-serif',
+    h1: { fontSize: '1.6rem', fontWeight: 650, letterSpacing: '-0.02em' },
+    h2: { fontSize: '1.25rem', fontWeight: 650, letterSpacing: '-0.015em' },
+    h3: { fontSize: '1.05rem', fontWeight: 600 },
+    subtitle2: { fontWeight: 600 },
+    button: { textTransform: 'none' as const, fontWeight: 600 },
+  },
+}
+
+const componentOverrides = (theme: Theme) => ({
+  MuiCssBaseline: {
+    styleOverrides: {
+      '*::-webkit-scrollbar': { width: 10, height: 10 },
+      '*::-webkit-scrollbar-thumb': {
+        backgroundColor: theme.palette.divider,
+        borderRadius: 8,
+        border: `2px solid ${theme.palette.background.default}`,
+      },
+      code: { fontFamily: '"JetBrains Mono", ui-monospace, monospace', fontSize: '0.85em' },
+    },
+  },
+  MuiPaper: { styleOverrides: { root: { backgroundImage: 'none' } } },
+  MuiTooltip: {
+    styleOverrides: {
+      tooltip: { fontSize: '0.78rem', lineHeight: 1.45, maxWidth: 340 },
+    },
+  },
+  MuiChip: { styleOverrides: { root: { fontWeight: 500 } } },
+})
+
+export const buildTheme = (mode: 'light' | 'dark'): Theme => {
+  const base = createTheme({
+    ...shared,
+    palette:
+      mode === 'dark'
+        ? {
+            mode,
+            primary: { main: '#5eead4' },
+            secondary: { main: '#a78bfa' },
+            background: { default: '#0f1419', paper: '#161c23' },
+            divider: 'rgba(148, 163, 184, 0.22)',
+          }
+        : {
+            mode,
+            primary: { main: '#0f766e' },
+            secondary: { main: '#6d28d9' },
+            background: { default: '#f4f6f8', paper: '#ffffff' },
+            divider: 'rgba(15, 23, 42, 0.12)',
+          },
+  })
+
+  return createTheme(base, { components: componentOverrides(base) })
+}

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Overrides the API base path; defaults to the same-origin `/api`. */
+  readonly VITE_API_BASE?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+const API_TARGET = process.env.FEDOTWEB_API ?? 'http://127.0.0.1:8000'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      // Keeps the browser on a single origin during development, so the
+      // WebSocket used for run progress needs no special-casing.
+      '/api': { target: API_TARGET, changeOrigin: true, ws: true },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        // The canvas and the charts are each only needed on one screen, so
+        // splitting them keeps the first paint off the critical path.
+        manualChunks: {
+          react: ['react', 'react-dom', 'react-router-dom'],
+          mui: ['@mui/material', '@mui/icons-material', '@emotion/react', '@emotion/styled'],
+          flow: ['@xyflow/react', '@dagrejs/dagre'],
+          charts: ['recharts'],
+        },
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Motivation

FEDOT.Web has not kept up with the frameworks it fronts: the backend is pinned to `fedot==0.7.3.1` on Flask 2.2 (whose `@app.before_first_request` was removed in Flask 2.3), the frontend is React 17 with Material-UI v4 (EOL since 2021) and a dagre-d3 canvas with zoom commented out, MongoDB is required just to start, and the GUI can only replay pre-seeded showcase cases — it cannot run FEDOT on user data.

This PR adds a version 2 that lives alongside the legacy code (`app/` and `frontend/` are untouched): a FastAPI backend in `backend/fedotweb` and a Vite + React 19 + TypeScript frontend in `ui/`. It targets FEDOT master / GOLEM 0.4.2, starts with `pip install` + `npm run build` and no external services, and drives the framework instead of only displaying results.

## What it does

**Pipeline structure and hyperparameters.** The editor is React Flow with dagre layout, zoom/pan/minimap. Each node card shows the operation, its category and the hyperparameters that differ from FEDOT's defaults. The hyperparameter editor is generated from what FEDOT itself publishes — `PipelineSearchSpace` (type, sampling scope, distribution), `default_operation_params.json`, and the operation repositories — so a continuous parameter gets a slider bounded by the tuner's real range (logarithmic for `loguniform`), a discrete one an integer stepper, a categorical one a dropdown of admissible values; nested spaces such as `glm` become variant selectors. Validation is task-aware, with FEDOT's rule messages made readable.

**Running FEDOT.** Upload a CSV, inspect inferred column types, pick a target, configure a run (task, preset, metric, time budget, population, generations, depth/arity, CV folds, early stopping, seed, tuning) and launch it. Runs execute in worker subprocesses; progress streams per generation over WebSocket from GOLEM's iteration callback. Metrics are computed on a holdout split the composer never saw.

**Evolution history as a live genealogy.** Individuals and the operators that produced them (mutation/crossover), laid out generation by generation; survivors are linked across generations with dashed edges. By default only the ancestry of the current best is drawn, with a toggle for the whole population. The graph is available *during* the run — assembled from progress events — and switches to the saved `OptHistory` on completion; both sources share one builder, so the live and final drawings are identical. Clicking an individual opens its pipeline with the hyperparameters evolution chose.

**Interactive control of a live run.** Population size, mutation/crossover probabilities, generation limit and time budget can be changed between generations, and *Finish now* ends a run through the optimiser's normal path so the best pipeline is still fitted and saved. GOLEM re-derives `pop_size` and the operator probabilities every generation in `_update_requirements`, so plain assignment would not stick; the controls wrap the `AdaptiveParameter` sources instead, and releasing an override resumes the adaptive schedule.

**Attach mode.** `import fedotweb.autowatch` in a user's own script opens the GUI on the next `fit()`: the server starts if needed, a browser tab opens on the run, and every generation is reported with the same genealogy and controls. An explicit `watch()` context manager is available when the run should be named or the results stored.

**On-demand analyses.** *Objective breakdown* recomputes the per-fold metrics behind the averaged fitness value (on the same `DataSourceSplitter` split the composer used), showing each fold, the mean — which is the number evolution compared pipelines by — the spread, and the holdout score. *Sensitivity* runs GOLEM's structural analysis (node deletion/replacement, subtree deletion, edge deletion/replacement) and reports a verdict per node and edge. *Preprocessing report* runs FEDOT's own preprocessor and shows, per source column, the types found in the file and the type the pipeline finally receives — e.g. an integer column with < 13 distinct values arriving as `str`.

## Notes for reviewers

- The base of `PipelineNode` conversion is built in topological order; the legacy recursive rebuild de-duplicated nodes by `descriptive_id`, which silently merged structurally identical parallel branches (there is a regression test).
- FEDOT is installed from master rather than PyPI: the released 0.7.5 wheel pins `thegolem==0.4.1` and passes `raise_if_test`/`exc` kwargs into logging, which raises `TypeError` on the first badly scoring pipeline (reproducible with the `best_quality` preset; already fixed on master). A defensive shim remains for users on the release wheel.
- GOLEM's structural-analysis ratio is sign-normalised, and `optimize()` applies changes at ratio > 1 — i.e. above 1 means the change *improved* the objective. The backend ships this verdict per entity so clients don't have to rediscover the convention.
- GOLEM histories store `initial_assumptions` / `final_choices` as pseudo-generations, and its live generation counter is offset by one from `native_generation`; the genealogy builder is written to be correct for both numbering schemes and labels the pseudo-generations explicitly.
- Preprocessing indices need care: the gap filter drops columns first, and the type corrector then indexes the filtered matrix, so its indices are mapped back to source file columns before display.

## Verification

- 73 pytest cases, including integration tests that run real (short) compositions end-to-end: upload → run → live lineage → controls → finish-now → analyses.
- `ruff` clean, `tsc --noEmit` clean, production build clean.
- Exercised manually against real runs: live genealogy growth without reloads, mid-run control changes taking effect on the next generation, sensitivity verdicts matching intuition (a duplicated `scaling` reads as removable, the `scaling` before `logit` as load-bearing).

## Known limitations

- No authentication: v2 binds to localhost and must not be exposed to a network as-is (v1's guest login was dropped).
- Docker image installs FEDOT from master; pin to the next release once it ships.
- The legacy MongoDB showcase flow is not ported; SQLite is the default store, Mongo remains optional via `FEDOTWEB_MONGO_URI`.


## Follow-up commits

- UI: best-only fitness chart with leader-change markers, population view behind a checkbox, OptHistory JSON download, operator hover diffs, default-hyperparameter details, editor handoff fix, value rounding, label overlap fixes.
- Worker: the run's own time budget now overrides FEDOT's 10-minute `early_stopping_timeout` default, which silently truncated longer searches; stagnation control stays available explicitly.
- Worker: explicit `available_operations` now reaches mutations and verification (`_honor_available_operations`). This works around aimclub/FEDOT#1447; the workaround is marked for removal once that fix is released.
- `backend/examples/evolution_story_dataset.py`: a generator for data on which the evolution history is genuinely interesting (seed pipelines capped at AUC 0.67, `scaling -> mlp` / `qda` summit at 0.87). With the fixes above a 20-minute run climbs CV AUC 0.61 -> 0.89 over 82 generations with twelve leader changes (holdout ROC AUC 0.925).